### PR TITLE
fix(ci): switch lint to eslint CLI for Next 16 compatibility

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,21 +1,19 @@
-// For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
-import storybook from "eslint-plugin-storybook";
+import nextCoreWebVitals from 'eslint-config-next/core-web-vitals'
+import storybook from 'eslint-plugin-storybook'
 
-import { dirname } from 'path'
-import { fileURLToPath } from 'url'
-import { FlatCompat } from '@eslint/eslintrc'
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-})
-
-const eslintConfig = [
-  ...compat.extends('next/core-web-vitals'),
-  ...storybook.configs["flat/recommended"]
+const config = [
+  {
+    ignores: [
+      '**/.next/**',
+      '**/out/**',
+      '**/node_modules/**',
+      '**/storybook-static/**',
+      '**/dist/**',
+      '.claude/**',
+    ],
+  },
+  ...nextCoreWebVitals,
+  ...storybook.configs['flat/recommended'],
 ]
 
-export default eslintConfig
-
+export default config

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "eslint .",
     "test": "vitest run",
     "export-content": "contentful space export --config contentful-cli-config.json",
     "generate-types": "cf-content-types-generator src/contentful-types/*.json -o src/app/generated-types -X",


### PR DESCRIPTION
## Summary
- `package.json`: `lint` script from `next lint` → `eslint .`
- `eslint.config.mjs`: drop the `FlatCompat` shim; import `eslint-config-next/core-web-vitals` directly (it's a native flat-config array in v16)
- Tighten ignores so sub-worktree `.next/` build artifacts and `.claude/` are skipped

## Why
Next 16 removed the `next lint` subcommand, which broke CI on every PR opened after the CI workflow landed in #1. All pending PRs (#2, #3) are failing the CI lint step because of this. Follow-up to my own earlier oversight — I added the CI step without verifying the lint script still worked on Next 16.

## Test plan
- [x] `npm run lint` exits 0 locally (1 baseline-browser-mapping data-age warning from the upstream package; no lint errors)
- [ ] CI turns green on this PR
- [ ] PR #3 (design tokens) CI goes green after this lands + rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)