### PR TITLE
feat(typography): add H1-H5, P, Detail, FieldInput primitives

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -6,7 +6,7 @@ import Image from 'next/image'
 import { notFound } from 'next/navigation'
 import type { ReactNode } from 'react'
 import { Author } from '../components/blog/author'
-import { Heading4 } from '../components/typography'
+import { H4 } from '../components/typography'
 import { getAllPosts, getAssetUrl, getAuthorInfo, getPostBySlug } from '../lib/api'
 import { BackButton } from './back-button'
 
@@ -174,7 +174,7 @@ export default async function BlogPostPage({ params }: Props) {
         <Separator className="my-10" />
 
         <footer className="mt-10 prose dark:prose-invert max-w-none">
-          <Heading4>About Orbs</Heading4>
+          <H4>About Orbs</H4>
 
           <p>
             Orbs is a decentralized Layer-3 (L3) blockchain designed specifically for advanced on-chain trading.

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next'
-import { Heading1 } from '../components/typography'
+import { H1 } from '../components/typography'
 import { getAllPosts } from '../lib/api'
 import { BlogCard } from './blog-card'
 
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 function Heading() {
   return (
     <div className="flex flex-col items-center justify-center pt-10 pb-32">
-      <Heading1 className="inline-block text-center mx-auto">The Orbs Project Blog</Heading1>
+      <H1 className="inline-block text-center mx-auto">The Orbs Project Blog</H1>
       <p className="text-gray-600 dark:text-gray-400">
         Thoughts about the Orbs project, open source, blockchain and engineering.
       </p>

--- a/src/app/components/typography.stories.tsx
+++ b/src/app/components/typography.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+
+import { Detail, FieldInput, H1, H2, H3, H4, H5, P } from './typography'
+
+const meta = {
+  title: 'Typography/Primitives',
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const sample = 'The quick brown fox jumps over the lazy dog'
+
+export const All: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+  render: () => (
+    <div className="flex flex-col gap-8 bg-bg p-8">
+      <section className="flex flex-col gap-2">
+        <span className="text-detail text-fg-muted font-medium uppercase">H1 — 72/80 · 400</span>
+        <H1>{sample}</H1>
+      </section>
+      <section className="flex flex-col gap-2">
+        <span className="text-detail text-fg-muted font-medium uppercase">H2 — 56/64 · 400</span>
+        <H2>{sample}</H2>
+      </section>
+      <section className="flex flex-col gap-2">
+        <span className="text-detail text-fg-muted font-medium uppercase">H3 regular — 32/40 · 400</span>
+        <H3>{sample}</H3>
+        <span className="text-detail text-fg-muted font-medium uppercase">H3 medium — 32/40 · 600</span>
+        <H3 weight="medium">{sample}</H3>
+      </section>
+      <section className="flex flex-col gap-2">
+        <span className="text-detail text-fg-muted font-medium uppercase">H4 — 22/30 · 400</span>
+        <H4>{sample}</H4>
+      </section>
+      <section className="flex flex-col gap-2">
+        <span className="text-detail text-fg-muted font-medium uppercase">H5 — 14/20 · 600 · uppercase</span>
+        <H5>{sample}</H5>
+      </section>
+      <section className="flex flex-col gap-2">
+        <span className="text-detail text-fg-muted font-medium uppercase">P — 18/28 · 400</span>
+        <P>{sample}</P>
+      </section>
+      <section className="flex flex-col gap-2">
+        <span className="text-detail text-fg-muted font-medium uppercase">Detail — 11/16 · 500 · uppercase</span>
+        <Detail>{sample}</Detail>
+      </section>
+      <section className="flex flex-col gap-2">
+        <span className="text-detail text-fg-muted font-medium uppercase">FieldInput — 20/28 · 400</span>
+        <FieldInput>{sample}</FieldInput>
+      </section>
+    </div>
+  ),
+}
+
+export const H1Story: Story = {
+  name: 'H1',
+  render: () => <H1>{sample}</H1>,
+}
+
+export const H2Story: Story = {
+  name: 'H2',
+  render: () => <H2>{sample}</H2>,
+}
+
+export const H3Regular: Story = {
+  name: 'H3 / Regular',
+  render: () => <H3>{sample}</H3>,
+}
+
+export const H3Medium: Story = {
+  name: 'H3 / Medium',
+  render: () => <H3 weight="medium">{sample}</H3>,
+}
+
+export const H4Story: Story = {
+  name: 'H4',
+  render: () => <H4>{sample}</H4>,
+}
+
+export const H5Story: Story = {
+  name: 'H5',
+  render: () => <H5>{sample}</H5>,
+}
+
+export const PStory: Story = {
+  name: 'P',
+  render: () => <P>{sample}</P>,
+}
+
+export const DetailStory: Story = {
+  name: 'Detail',
+  render: () => <Detail>{sample}</Detail>,
+}
+
+export const FieldInputStory: Story = {
+  name: 'FieldInput',
+  render: () => <FieldInput>{sample}</FieldInput>,
+}

--- a/src/app/components/typography.tsx
+++ b/src/app/components/typography.tsx
@@ -1,46 +1,80 @@
+import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
+
 import { cn } from '@/lib/utils'
 
-export function Heading1({ children, className }: { children: React.ReactNode; className?: string }) {
-  return (
-    <h1
-      className={cn(
-        'text-4xl font-black mb-4 uppercase bg-clip-text text-transparent bg-gradient-to-r from-primary to-secondary',
-        className
-      )}
-    >
-      {children}
-    </h1>
-  )
+type PolymorphicProps<E extends React.ElementType> = React.ComponentPropsWithoutRef<E> & {
+  asChild?: boolean
+  className?: string
 }
 
-export function Heading2({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <h2 className={cn('text-3xl font-bold mb-4', className)}>{children}</h2>
+export const H1 = React.forwardRef<HTMLHeadingElement, PolymorphicProps<'h1'>>(
+  ({ asChild = false, className, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'h1'
+    return <Comp ref={ref} className={cn('text-h1 text-fg font-normal', className)} {...props} />
+  }
+)
+H1.displayName = 'H1'
+
+export const H2 = React.forwardRef<HTMLHeadingElement, PolymorphicProps<'h2'>>(
+  ({ asChild = false, className, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'h2'
+    return <Comp ref={ref} className={cn('text-h2 text-fg font-normal', className)} {...props} />
+  }
+)
+H2.displayName = 'H2'
+
+export type H3Weight = 'regular' | 'medium'
+
+export interface H3Props extends PolymorphicProps<'h3'> {
+  weight?: H3Weight
 }
 
-export function Heading3({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <h3 className={cn('text-2xl font-bold mb-4', className)}>{children}</h3>
-}
+export const H3 = React.forwardRef<HTMLHeadingElement, H3Props>(
+  ({ asChild = false, className, weight = 'regular', ...props }, ref) => {
+    const Comp = asChild ? Slot : 'h3'
+    const weightClass = weight === 'medium' ? 'font-semibold' : 'font-normal'
+    return <Comp ref={ref} className={cn('text-h3 text-fg', weightClass, className)} {...props} />
+  }
+)
+H3.displayName = 'H3'
 
-export function Heading4({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <h4 className={cn('text-xl font-bold mb-4', className)}>{children}</h4>
-}
+export const H4 = React.forwardRef<HTMLHeadingElement, PolymorphicProps<'h4'>>(
+  ({ asChild = false, className, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'h4'
+    return <Comp ref={ref} className={cn('text-h4 text-fg font-normal', className)} {...props} />
+  }
+)
+H4.displayName = 'H4'
 
-export function Heading5({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <h5 className={cn('text-lg font-bold mb-4', className)}>{children}</h5>
-}
+export const H5 = React.forwardRef<HTMLHeadingElement, PolymorphicProps<'h5'>>(
+  ({ asChild = false, className, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'h5'
+    return <Comp ref={ref} className={cn('text-h5 text-fg font-semibold uppercase', className)} {...props} />
+  }
+)
+H5.displayName = 'H5'
 
-export function Heading6({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <h6 className={cn('text-base font-bold mb-4', className)}>{children}</h6>
-}
+export const P = React.forwardRef<HTMLParagraphElement, PolymorphicProps<'p'>>(
+  ({ asChild = false, className, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'p'
+    return <Comp ref={ref} className={cn('text-p text-fg font-normal', className)} {...props} />
+  }
+)
+P.displayName = 'P'
 
-export function Paragraph({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <p className={cn('text-base mb-4', className)}>{children}</p>
-}
+export const Detail = React.forwardRef<HTMLSpanElement, PolymorphicProps<'span'>>(
+  ({ asChild = false, className, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'span'
+    return <Comp ref={ref} className={cn('text-detail text-fg font-medium uppercase', className)} {...props} />
+  }
+)
+Detail.displayName = 'Detail'
 
-export function List({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <ul className={cn('list-disc list-inside mb-4', className)}>{children}</ul>
-}
-
-export function ListItem({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <li className={cn('mb-2', className)}>{children}</li>
-}
+export const FieldInput = React.forwardRef<HTMLSpanElement, PolymorphicProps<'span'>>(
+  ({ asChild = false, className, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'span'
+    return <Comp ref={ref} className={cn('text-field text-fg font-normal', className)} {...props} />
+  }
+)
+FieldInput.displayName = 'FieldInput'

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button'
 import Link from 'next/link'
 import { BlogCard } from './blog/blog-card'
 import { OrbsLogo } from '@/components/icons'
-import { Heading1, Heading3 } from './components/typography'
+import { H1, H3 } from './components/typography'
 import { getAllPosts } from './lib/api'
 
 export default async function Home() {
@@ -15,7 +15,7 @@ export default async function Home() {
         <div className="mb-6 flex justify-center items-center">
           <OrbsLogo className="w-48 h-auto" />
         </div>
-        <Heading1 className="mb-8">Bringing CeFi execution to DeFi</Heading1>
+        <H1 className="mb-8">Bringing CeFi execution to DeFi</H1>
 
         <Button asChild size="lg" className="uppercase font-semibold">
           <Link href="/blog">View Blog</Link>
@@ -25,7 +25,7 @@ export default async function Home() {
       {/* Recent Posts Section */}
       {recentPosts.length > 0 && (
         <section>
-          <Heading3>Recent Posts</Heading3>
+          <H3 weight="medium">Recent Posts</H3>
           <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
             {recentPosts.map((post) => (
               <BlogCard key={post.slug} post={post} />


### PR DESCRIPTION
## Summary
- New typography primitives: H1, H2, H3 (weight: 'regular' | 'medium'), H4, H5, P, Detail, FieldInput
- All support `asChild`, className merge, full HTML prop forwarding
- Stories covering all components in light + dark

## Why
Wave 1.1 of the design-system rollout (see `docs/design-system-plan.md`). Replaces the ad-hoc Heading components with the full Orbs type scale wired to the Wave 0 tokens.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` green (Storybook browser tests)
- [x] Homepage + slug page still render with the new typography names

🤖 Generated with [Claude Code](https://claude.com/claude-code)