### PR TITLE
feat(field): add underlined input primitive

### DIFF
--- a/src/components/ui/field.stories.tsx
+++ b/src/components/ui/field.stories.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react'
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+
+import { Field } from './field'
+
+const meta = {
+  title: 'UI/Field',
+  component: Field,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Placeholder/label text rendered inside the input',
+    },
+    error: {
+      control: 'text',
+      description: 'Optional error message shown beneath the input',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the field is disabled',
+    },
+    type: {
+      control: 'select',
+      options: ['text', 'email', 'password', 'tel', 'url', 'number'],
+      description: 'The HTML input type',
+    },
+  },
+  args: {
+    onChange: fn(),
+    label: 'Your name',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Field>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    label: 'Your name',
+  },
+}
+
+export const Filled: Story = {
+  args: {
+    label: 'Your name',
+  },
+  render: (args) => {
+    const ControlledField = () => {
+      const [value, setValue] = React.useState('Ada Lovelace')
+      return <Field {...args} value={value} onChange={(e) => setValue(e.target.value)} />
+    }
+    return <ControlledField />
+  },
+}
+
+export const Focused: Story = {
+  args: {
+    label: 'Your name',
+    autoFocus: true,
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    label: 'Your name',
+    disabled: true,
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    label: 'Email',
+    type: 'email',
+    defaultValue: 'not-an-email',
+    error: 'Please enter a valid email address',
+  },
+}
+
+export const Email: Story = {
+  args: {
+    label: 'Email',
+    type: 'email',
+    name: 'email',
+  },
+}

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+export interface FieldProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  label?: string
+  error?: string
+}
+
+const Field = React.forwardRef<HTMLInputElement, FieldProps>(
+  ({ className, label, error, disabled, type = 'text', id, ...props }, ref) => {
+    const reactId = React.useId()
+    const inputId = id ?? reactId
+    const errorId = error ? `${inputId}-error` : undefined
+
+    return (
+      <div className={cn('flex w-full flex-col', className)}>
+        <input
+          ref={ref}
+          id={inputId}
+          type={type}
+          placeholder={label}
+          disabled={disabled}
+          aria-label={label}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={errorId}
+          className={cn(
+            'h-12 w-full border-0 border-b bg-transparent px-0 text-field text-fg outline-none transition-colors',
+            'placeholder:text-fg-muted',
+            'focus:outline-none focus-visible:outline-none',
+            error
+              ? 'border-b-[var(--destructive)] focus:border-b-[var(--destructive)]'
+              : 'border-border focus:border-accent-primary',
+            disabled && 'cursor-not-allowed text-fg-muted placeholder:text-fg-muted'
+          )}
+          {...props}
+        />
+        {error ? (
+          <p id={errorId} className="mt-2 text-detail text-coral-500">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    )
+  }
+)
+Field.displayName = 'Field'
+
+export { Field }


### PR DESCRIPTION
## Summary
- `src/components/ui/field.tsx` — underlined text input with label/focus/error states
- Stories in light + dark covering default / filled / focused / disabled / error / email

## Why
Wave 1.4 of the design-system rollout (`docs/design-system-plan.md`). Consumed by Wave 2.3 Signup Area and anywhere else we need form fields.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)