### PR TITLE
feat(tags): SearchTag + Badge primitives

### DIFF
--- a/src/components/ui/badge.stories.tsx
+++ b/src/components/ui/badge.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+
+import { Badge } from './badge'
+
+const meta = {
+  title: 'UI/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['research', 'partnership'],
+      description: 'The visual style of the badge',
+    },
+  },
+  args: {
+    children: 'Research',
+    variant: 'research',
+  },
+} satisfies Meta<typeof Badge>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Research: Story = {
+  args: {
+    variant: 'research',
+    children: 'Research',
+  },
+}
+
+export const Partnership: Story = {
+  args: {
+    variant: 'partnership',
+    children: 'Partnership',
+  },
+}
+
+export const Group: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+  render: () => (
+    <div className="flex flex-wrap items-center gap-3">
+      <Badge variant="research">Research</Badge>
+      <Badge variant="partnership">Partnership</Badge>
+    </div>
+  ),
+}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
+  variant: 'research' | 'partnership'
+}
+
+const badgeVariantClasses: Record<BadgeProps['variant'], string> = {
+  research: 'bg-periwinkle-200/50 text-periwinkle-600',
+  partnership: 'bg-coral-200/60 text-coral-600',
+}
+
+const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(({ className, variant, children, ...props }, ref) => {
+  return (
+    <span
+      ref={ref}
+      className={cn(
+        'inline-flex items-center rounded-full px-3 py-1 text-p font-medium',
+        badgeVariantClasses[variant],
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  )
+})
+Badge.displayName = 'Badge'
+
+export { Badge }

--- a/src/components/ui/search-tag.stories.tsx
+++ b/src/components/ui/search-tag.stories.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react'
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { fn } from 'storybook/test'
+
+import { SearchTag } from './search-tag'
+
+const meta = {
+  title: 'UI/SearchTag',
+  component: SearchTag,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    active: {
+      control: 'boolean',
+      description: 'Whether the tag is in the selected/active state',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the tag is disabled',
+    },
+  },
+  args: {
+    onClick: fn(),
+    children: 'Integration',
+  },
+} satisfies Meta<typeof SearchTag>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Inactive: Story = {
+  args: {
+    active: false,
+  },
+}
+
+export const Active: Story = {
+  args: {
+    active: true,
+  },
+}
+
+export const Group: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+  render: () => {
+    const labels = ['Integration', 'Partnership', 'Research'] as const
+    const [selected, setSelected] = React.useState<(typeof labels)[number]>('Partnership')
+    return (
+      <div className="flex flex-wrap items-center gap-2">
+        {labels.map((label) => (
+          <SearchTag key={label} active={selected === label} onClick={() => setSelected(label)}>
+            {label}
+          </SearchTag>
+        ))}
+      </div>
+    )
+  },
+}

--- a/src/components/ui/search-tag.tsx
+++ b/src/components/ui/search-tag.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+export interface SearchTagProps extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  active?: boolean
+  children: React.ReactNode
+}
+
+const SearchTag = React.forwardRef<HTMLButtonElement, SearchTagProps>(
+  ({ className, active = false, type = 'button', children, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        aria-pressed={active}
+        data-state={active ? 'active' : 'inactive'}
+        className={cn(
+          'inline-flex items-center justify-center rounded-full px-4 py-1.5 text-detail font-semibold uppercase transition-colors',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+          'disabled:pointer-events-none disabled:opacity-50',
+          active
+            ? 'bg-indigo-400 text-neutral-100 hover:bg-indigo-500'
+            : 'bg-periwinkle-200/40 text-periwinkle-500 hover:bg-periwinkle-200/60',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </button>
+    )
+  }
+)
+SearchTag.displayName = 'SearchTag'
+
+export { SearchTag }


### PR DESCRIPTION
## Summary
- `src/components/ui/search-tag.tsx` — clickable uppercase filter pill, inactive/active
- `src/components/ui/badge.tsx` — title-case label, research/partnership variants
- Stories covering every state in light + dark

## Why
Wave 1.5 of the design-system rollout (`docs/design-system-plan.md`). Consumed by Wave 2.1 Cards and 2.4 Resources Nav.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)