### PR TITLE
feat(buttons): Primary/Secondary + MenuItem/FooterLink/LargeLink

### DIFF
--- a/src/app/[slug]/back-button.tsx
+++ b/src/app/[slug]/back-button.tsx
@@ -8,7 +8,7 @@ export function BackButton() {
   const router = useRouter()
 
   return (
-    <Button variant="outline" onClick={router.back} size="sm">
+    <Button variant="secondary" onClick={router.back} size="sm">
       <ArrowLeftIcon className="size-4" /> Back
     </Button>
   )

--- a/src/app/components/layout/header.tsx
+++ b/src/app/components/layout/header.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@/components/ui/button'
-import { ArrowRightIcon } from 'lucide-react'
 import Link from 'next/link'
 import { ThemeToggle } from '../theme/theme-toggle'
 import { LanguageSelector } from './language-selector'
@@ -23,10 +22,7 @@ export function Header() {
           <div className="flex items-center gap-4">
             <ThemeToggle />
             <LanguageSelector />
-            <Button variant="outline" className="uppercase tracking-widest text-xs">
-              Get in Touch
-              <ArrowRightIcon className="size-4" />
-            </Button>
+            <Button size="sm">Get in Touch</Button>
           </div>
         </div>
       </div>

--- a/src/app/components/layout/language-selector.tsx
+++ b/src/app/components/layout/language-selector.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { ChevronDownIcon } from 'lucide-react'
 import { useState } from 'react'
@@ -11,14 +10,17 @@ export function LanguageSelector() {
   return (
     <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="text-xs">
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 text-xs text-fg transition-colors hover:text-accent-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
           {language}
           <ChevronDownIcon
             className="transition-transform duration-200 size-5"
             style={{ transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)' }}
           />
           <span className="sr-only">Language Selector</span>
-        </Button>
+        </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={() => setLanguage('EN')} className="text-xs">

--- a/src/app/components/layout/navigation/nav-button.tsx
+++ b/src/app/components/layout/navigation/nav-button.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import Link from 'next/link'
 
@@ -12,10 +11,15 @@ export function NavButton({
   className?: string
 }) {
   return (
-    <Button variant="ghost" asChild>
-      <Link href={href} className={cn('uppercase text-xs tracking-widest font-medium transition-colors', className)}>
-        {children}
-      </Link>
-    </Button>
+    <Link
+      href={href}
+      className={cn(
+        'inline-flex items-center gap-1 uppercase text-xs tracking-widest font-medium text-fg transition-colors',
+        'hover:text-accent-primary',
+        className
+      )}
+    >
+      {children}
+    </Link>
   )
 }

--- a/src/app/components/theme/theme-toggle.tsx
+++ b/src/app/components/theme/theme-toggle.tsx
@@ -3,7 +3,6 @@
 import { Computer, Moon, Sun } from 'lucide-react'
 import { useTheme } from 'next-themes'
 
-import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 
 export function ThemeToggle() {
@@ -11,11 +10,15 @@ export function ThemeToggle() {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon">
+        <button
+          type="button"
+          aria-label="Toggle theme"
+          className="relative inline-flex size-9 items-center justify-center text-fg transition-colors hover:text-accent-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        >
           <Sun className="size-4 scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
           <Moon className="absolute size-4 scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
           <span className="sr-only">Toggle theme</span>
-        </Button>
+        </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem onClick={() => setTheme('light')} className="text-xs">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ export default async function Home() {
         </div>
         <H1 className="mb-8">Bringing CeFi execution to DeFi</H1>
 
-        <Button asChild size="lg" className="uppercase font-semibold">
+        <Button asChild size="lg">
           <Link href="/blog">View Blog</Link>
         </Button>
       </section>

--- a/src/components/ui/button.stories.tsx
+++ b/src/components/ui/button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { fn } from 'storybook/test'
-import { Mail, ChevronRight, Loader2 } from 'lucide-react'
+import { Download } from 'lucide-react'
 
 import { Button } from './button'
 
@@ -14,13 +14,13 @@ const meta = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],
-      description: 'The visual style of the button',
+      options: ['primary', 'secondary'],
+      description: 'Visual style of the button',
     },
     size: {
       control: 'select',
-      options: ['default', 'sm', 'lg', 'icon'],
-      description: 'The size of the button',
+      options: ['sm', 'default', 'lg'],
+      description: 'Size of the button',
     },
     asChild: {
       control: 'boolean',
@@ -30,50 +30,62 @@ const meta = {
       control: 'boolean',
       description: 'Whether the button is disabled',
     },
+    noIcon: {
+      control: 'boolean',
+      description: 'Suppress the trailing icon (primary variant only)',
+    },
   },
   args: {
     onClick: fn(),
-    children: 'Button',
+    children: 'Get in Touch',
   },
 } satisfies Meta<typeof Button>
 
 export default meta
 type Story = StoryObj<typeof meta>
 
-// Variants
-export const Default: Story = {
+// Primary variant states
+export const Primary: Story = {
   args: {
-    variant: 'default',
+    variant: 'primary',
   },
 }
 
+export const PrimaryDisabled: Story = {
+  args: {
+    variant: 'primary',
+    disabled: true,
+  },
+}
+
+export const PrimaryNoIcon: Story = {
+  args: {
+    variant: 'primary',
+    noIcon: true,
+  },
+}
+
+export const PrimaryCustomIcon: Story = {
+  args: {
+    variant: 'primary',
+    children: 'Download',
+    icon: <Download className="size-4" />,
+  },
+}
+
+// Secondary variant states
 export const Secondary: Story = {
   args: {
     variant: 'secondary',
+    children: 'Join Community',
   },
 }
 
-export const Destructive: Story = {
+export const SecondaryDisabled: Story = {
   args: {
-    variant: 'destructive',
-  },
-}
-
-export const Outline: Story = {
-  args: {
-    variant: 'outline',
-  },
-}
-
-export const Ghost: Story = {
-  args: {
-    variant: 'ghost',
-  },
-}
-
-export const Link: Story = {
-  args: {
-    variant: 'link',
+    variant: 'secondary',
+    children: 'Join Community',
+    disabled: true,
   },
 }
 
@@ -81,88 +93,87 @@ export const Link: Story = {
 export const Small: Story = {
   args: {
     size: 'sm',
-    children: 'Small Button',
+    children: 'Small',
+  },
+}
+
+export const Default: Story = {
+  args: {
+    size: 'default',
   },
 }
 
 export const Large: Story = {
   args: {
     size: 'lg',
-    children: 'Large Button',
+    children: 'Large',
   },
 }
 
-export const Icon: Story = {
-  args: {
-    size: 'icon',
-    children: <ChevronRight className="h-4 w-4" />,
-    'aria-label': 'Next',
-  },
-}
-
-// With Icons
-export const WithIcon: Story = {
-  args: {
-    children: (
-      <>
-        <Mail className="h-4 w-4" />
-        Login with Email
-      </>
-    ),
-  },
-}
-
-export const IconRight: Story = {
-  args: {
-    children: (
-      <>
-        Continue
-        <ChevronRight className="h-4 w-4" />
-      </>
-    ),
-  },
-}
-
-// States
-export const Disabled: Story = {
-  args: {
-    disabled: true,
-  },
-}
-
-export const Loading: Story = {
-  args: {
-    disabled: true,
-    children: (
-      <>
-        <Loader2 className="h-4 w-4 animate-spin" />
-        Please wait
-      </>
-    ),
-  },
-}
-
-// All Variants Overview
-export const AllVariants: Story = {
+// All combinations
+export const AllStates: Story = {
   parameters: {
     controls: { hideNoControlsWarning: true },
   },
   render: () => (
-    <div className="flex flex-col gap-4">
-      <div className="flex flex-wrap items-center gap-4">
-        <Button variant="default">Default</Button>
-        <Button variant="secondary">Secondary</Button>
-        <Button variant="destructive">Destructive</Button>
-        <Button variant="outline">Outline</Button>
-        <Button variant="ghost">Ghost</Button>
-        <Button variant="link">Link</Button>
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-3">
+        <p className="text-detail uppercase tracking-wide text-fg-muted">Primary</p>
+        <div className="flex flex-wrap items-center gap-4">
+          <Button variant="primary">Get in Touch</Button>
+          <Button variant="primary" disabled>
+            Get in Touch
+          </Button>
+        </div>
       </div>
+      <div className="flex flex-col gap-3">
+        <p className="text-detail uppercase tracking-wide text-fg-muted">Secondary</p>
+        <div className="flex flex-wrap items-center gap-4">
+          <Button variant="secondary">Join Community</Button>
+          <Button variant="secondary" disabled>
+            Join Community
+          </Button>
+        </div>
+      </div>
+      <div className="flex flex-col gap-3">
+        <p className="text-detail uppercase tracking-wide text-fg-muted">Sizes</p>
+        <div className="flex flex-wrap items-center gap-4">
+          <Button size="sm">Small</Button>
+          <Button size="default">Default</Button>
+          <Button size="lg">Large</Button>
+        </div>
+        <div className="flex flex-wrap items-center gap-4">
+          <Button variant="secondary" size="sm">
+            Small
+          </Button>
+          <Button variant="secondary" size="default">
+            Default
+          </Button>
+          <Button variant="secondary" size="lg">
+            Large
+          </Button>
+        </div>
+      </div>
+    </div>
+  ),
+}
+
+// Dark background rendering
+export const AllStatesDark: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+    backgrounds: { default: 'dark' },
+  },
+  render: () => (
+    <div className="dark bg-bg p-8">
       <div className="flex flex-wrap items-center gap-4">
-        <Button size="sm">Small</Button>
-        <Button size="default">Default</Button>
-        <Button size="lg">Large</Button>
-        <Button size="icon">
-          <ChevronRight className="h-4 w-4" />
+        <Button variant="primary">Get in Touch</Button>
+        <Button variant="primary" disabled>
+          Get in Touch
+        </Button>
+        <Button variant="secondary">Join Community</Button>
+        <Button variant="secondary" disabled>
+          Join Community
         </Button>
       </div>
     </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,45 +1,101 @@
 import * as React from 'react'
 import { Slot } from '@radix-ui/react-slot'
 import { cva, type VariantProps } from 'class-variance-authority'
+import { ArrowRight } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
+/**
+ * Orbs brand button. Two variants:
+ *
+ * - `primary` (default) — bordered, uppercase, trailing arrow.
+ * - `secondary` — identical styling minus the trailing arrow.
+ *
+ * Shared states: default / disabled / hover (border + text + arrow all switch
+ * to the accent colour on hover, or `fg-muted` when disabled).
+ *
+ * Icon behaviour:
+ * - The primary variant auto-renders a Lucide `ArrowRight` after the children.
+ * - Pass a custom `icon` (ReactNode) to override the default arrow.
+ * - Pass `noIcon` to suppress the trailing icon entirely (useful when `asChild`
+ *   is wrapping a Link whose icon you want to control manually).
+ * - The secondary variant never renders an icon automatically.
+ */
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[var(--radius)] text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0',
+  [
+    'inline-flex items-center justify-center gap-2 whitespace-nowrap',
+    'font-semibold uppercase tracking-wide',
+    'border transition-colors',
+    'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+    'disabled:pointer-events-none disabled:border-fg-muted disabled:text-fg-muted',
+    '[&_svg]:pointer-events-none [&_svg]:shrink-0',
+    'border-fg text-fg hover:border-accent-primary hover:text-accent-primary',
+  ].join(' '),
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
-        outline: 'border border-foreground bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
+        primary: '',
+        secondary: '',
       },
       size: {
-        default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-[var(--radius)] px-3 text-xs',
-        lg: 'h-10 rounded-[var(--radius)] px-8',
-        icon: 'h-9 w-9',
+        sm: 'px-3 py-1.5 text-detail',
+        default: 'px-3.5 py-2.5 text-h5',
+        lg: 'px-5 py-3 text-field',
       },
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'primary',
       size: 'default',
     },
   }
 )
 
+const arrowSizeMap: Record<NonNullable<VariantProps<typeof buttonVariants>['size']>, string> = {
+  sm: 'size-3',
+  default: 'size-4',
+  lg: 'size-5',
+}
+
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean
+  /** Override the trailing icon. Defaults to `ArrowRight` on the primary variant. */
+  icon?: React.ReactNode
+  /** Suppress the trailing icon entirely (primary variant only). */
+  noIcon?: boolean
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant = 'primary', size = 'default', asChild = false, icon, noIcon, children, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button'
-    return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    const resolvedSize = size ?? 'default'
+
+    const showIcon = variant === 'primary' && !noIcon
+    const iconNode = showIcon ? (icon ?? <ArrowRight className={arrowSizeMap[resolvedSize]} aria-hidden="true" />) : null
+
+    const content =
+      asChild && React.isValidElement(children) ? (
+        React.cloneElement(children as React.ReactElement<{ children?: React.ReactNode }>, {
+          children: (
+            <>
+              {(children as React.ReactElement<{ children?: React.ReactNode }>).props.children}
+              {iconNode}
+            </>
+          ),
+        })
+      ) : (
+        <>
+          {children}
+          {iconNode}
+        </>
+      )
+
+    return (
+      <Comp className={cn(buttonVariants({ variant, size: resolvedSize, className }))} ref={ref} {...props}>
+        {content}
+      </Comp>
+    )
   }
 )
 Button.displayName = 'Button'

--- a/src/components/ui/footer-link.stories.tsx
+++ b/src/components/ui/footer-link.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+
+import { FooterLink1, FooterLink2 } from './footer-link'
+
+const meta = {
+  title: 'UI/FooterLink',
+  component: FooterLink1,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    href: { control: 'text' },
+    active: { control: 'boolean' },
+  },
+  args: {
+    href: '#',
+    children: 'Liquidity Hub',
+  },
+} satisfies Meta<typeof FooterLink1>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const FooterLink1Default: Story = {
+  args: {
+    active: false,
+  },
+}
+
+export const FooterLink1Active: Story = {
+  args: {
+    active: true,
+  },
+}
+
+type FooterLink2Story = StoryObj<typeof FooterLink2>
+
+export const FooterLink2Default: FooterLink2Story = {
+  render: () => <FooterLink2 href="#">Terms and Conditions</FooterLink2>,
+}
+
+export const FooterLink2Active: FooterLink2Story = {
+  render: () => (
+    <FooterLink2 href="#" active>
+      Terms and Conditions
+    </FooterLink2>
+  ),
+}
+
+export const AllStates: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <p className="text-detail uppercase tracking-wide text-fg-muted">Footer Link 1</p>
+        <FooterLink1 href="#">Liquidity Hub</FooterLink1>
+        <FooterLink1 href="#" active>
+          Liquidity Hub (active)
+        </FooterLink1>
+      </div>
+      <div className="flex flex-col gap-2">
+        <p className="text-detail uppercase tracking-wide text-fg-muted">Footer Link 2</p>
+        <FooterLink2 href="#">Terms and Conditions</FooterLink2>
+        <FooterLink2 href="#" active>
+          Terms and Conditions (active)
+        </FooterLink2>
+      </div>
+    </div>
+  ),
+}
+
+export const AllStatesDark: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+    backgrounds: { default: 'dark' },
+  },
+  render: () => (
+    <div className="dark bg-bg p-8">
+      <div className="flex flex-col gap-6">
+        <FooterLink1 href="#">Liquidity Hub</FooterLink1>
+        <FooterLink1 href="#" active>
+          Liquidity Hub (active)
+        </FooterLink1>
+        <FooterLink2 href="#">Terms and Conditions</FooterLink2>
+        <FooterLink2 href="#" active>
+          Terms and Conditions (active)
+        </FooterLink2>
+      </div>
+    </div>
+  ),
+}

--- a/src/components/ui/footer-link.tsx
+++ b/src/components/ui/footer-link.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+type BaseProps = {
+  href?: string
+  active?: boolean
+  className?: string
+  children: React.ReactNode
+}
+
+type AnchorProps = BaseProps & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps>
+type ButtonNativeProps = BaseProps & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>
+
+export type FooterLinkProps = AnchorProps | ButtonNativeProps
+
+function renderFooterLink(
+  classes: string,
+  { href, active, children, ref, ...rest }: FooterLinkProps & { ref: React.Ref<HTMLAnchorElement | HTMLButtonElement> }
+) {
+  if (href !== undefined) {
+    return (
+      <a
+        ref={ref as React.Ref<HTMLAnchorElement>}
+        href={href}
+        aria-current={active ? 'page' : undefined}
+        className={classes}
+        {...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+      >
+        {children}
+      </a>
+    )
+  }
+
+  return (
+    <button
+      ref={ref as React.Ref<HTMLButtonElement>}
+      type="button"
+      aria-current={active ? 'page' : undefined}
+      className={classes}
+      {...(rest as React.ButtonHTMLAttributes<HTMLButtonElement>)}
+    >
+      {children}
+    </button>
+  )
+}
+
+/**
+ * Uppercase footer link (e.g. "LIQUIDITY HUB").
+ * - Default: `text-fg-muted`
+ * - Hover: `text-link` (no underline)
+ */
+export const FooterLink1 = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, FooterLinkProps>(
+  ({ active = false, className, ...props }, ref) => {
+    const classes = cn(
+      'inline-flex items-center uppercase font-medium text-detail tracking-wide transition-colors',
+      'hover:text-link',
+      active ? 'text-link' : 'text-fg-muted',
+      className
+    )
+
+    return renderFooterLink(classes, { ...props, active, ref })
+  }
+)
+FooterLink1.displayName = 'FooterLink1'
+
+/**
+ * Uppercase footer link with hover underline (e.g. "TERMS AND CONDITIONS").
+ * - Default: `text-fg-muted`
+ * - Hover: `text-link` + underline
+ */
+export const FooterLink2 = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, FooterLinkProps>(
+  ({ active = false, className, ...props }, ref) => {
+    const classes = cn(
+      'inline-flex items-center uppercase font-medium text-detail tracking-wide transition-colors underline-offset-4',
+      'hover:text-link hover:underline',
+      active ? 'text-link underline' : 'text-fg-muted',
+      className
+    )
+
+    return renderFooterLink(classes, { ...props, active, ref })
+  }
+)
+FooterLink2.displayName = 'FooterLink2'

--- a/src/components/ui/large-link.stories.tsx
+++ b/src/components/ui/large-link.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+
+import { LargeLink } from './large-link'
+
+const meta = {
+  title: 'UI/LargeLink',
+  component: LargeLink,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    href: { control: 'text' },
+    disabled: { control: 'boolean' },
+  },
+  args: {
+    href: '#',
+    children: 'Whitepapers',
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-full max-w-3xl">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof LargeLink>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+}
+
+export const AllStates: Story = {
+  parameters: { controls: { hideNoControlsWarning: true } },
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <LargeLink href="#">Whitepapers</LargeLink>
+      <LargeLink href="#" disabled>
+        Whitepapers
+      </LargeLink>
+    </div>
+  ),
+}
+
+export const AllStatesDark: Story = {
+  parameters: { controls: { hideNoControlsWarning: true }, backgrounds: { default: 'dark' } },
+  render: () => (
+    <div className="dark bg-bg p-8">
+      <div className="flex flex-col gap-6">
+        <LargeLink href="#">Whitepapers</LargeLink>
+        <LargeLink href="#" disabled>
+          Whitepapers
+        </LargeLink>
+      </div>
+    </div>
+  ),
+}

--- a/src/components/ui/large-link.tsx
+++ b/src/components/ui/large-link.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import { ArrowRight } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+type BaseProps = {
+  href?: string
+  disabled?: boolean
+  className?: string
+  children: React.ReactNode
+}
+
+export type LargeLinkProps = BaseProps & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps>
+
+/**
+ * Full-width large link with a trailing arrow and a bottom border.
+ * States: default / disabled / hover — text, arrow, and border switch together.
+ */
+export const LargeLink = React.forwardRef<HTMLAnchorElement, LargeLinkProps>(
+  ({ href, disabled = false, className, children, ...props }, ref) => {
+    const classes = cn(
+      'group flex w-full items-center justify-between gap-4 border-b py-4 transition-colors',
+      'text-h2 font-normal',
+      disabled
+        ? 'pointer-events-none text-fg-muted border-fg-muted'
+        : 'text-fg border-border hover:text-accent-primary hover:border-accent-primary',
+      className
+    )
+
+    return (
+      <a
+        ref={ref}
+        href={disabled ? undefined : href}
+        aria-disabled={disabled || undefined}
+        tabIndex={disabled ? -1 : undefined}
+        className={classes}
+        {...props}
+      >
+        <span>{children}</span>
+        <ArrowRight className="size-8 shrink-0" aria-hidden="true" />
+      </a>
+    )
+  }
+)
+LargeLink.displayName = 'LargeLink'

--- a/src/components/ui/menu-item.stories.tsx
+++ b/src/components/ui/menu-item.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+
+import { MenuItem, MenuItemW } from './menu-item'
+
+const meta = {
+  title: 'UI/MenuItem',
+  component: MenuItem,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    href: { control: 'text' },
+    active: { control: 'boolean' },
+  },
+  args: {
+    href: '#',
+    children: 'Menu Item',
+  },
+} satisfies Meta<typeof MenuItem>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    active: false,
+  },
+}
+
+export const Active: Story = {
+  args: {
+    active: true,
+  },
+}
+
+export const AsButton: Story = {
+  args: {
+    href: undefined,
+    children: 'Menu Item (button)',
+  },
+}
+
+export const AllStates: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+  },
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <MenuItem href="#">Menu Item</MenuItem>
+      <MenuItem href="#" active>
+        Menu Item Active
+      </MenuItem>
+    </div>
+  ),
+}
+
+export const AllStatesDark: Story = {
+  parameters: {
+    controls: { hideNoControlsWarning: true },
+    backgrounds: { default: 'dark' },
+  },
+  render: () => (
+    <div className="dark bg-bg p-8">
+      <div className="flex flex-col gap-6">
+        <MenuItem href="#">Menu Item</MenuItem>
+        <MenuItem href="#" active>
+          Menu Item Active
+        </MenuItem>
+      </div>
+    </div>
+  ),
+}
+
+// MenuItemW (title-case + optional icon)
+type MenuItemWStory = StoryObj<typeof MenuItemW>
+
+export const MenuItemWDefault: MenuItemWStory = {
+  render: () => <MenuItemW href="#">Liquidity Hub</MenuItemW>,
+}
+
+export const MenuItemWWithIcon: MenuItemWStory = {
+  render: () => (
+    <MenuItemW
+      href="#"
+      icon={<span className="inline-block size-4 rounded-full bg-periwinkle-300" aria-hidden="true" />}
+    >
+      Liquidity Hub
+    </MenuItemW>
+  ),
+}
+
+export const MenuItemWActive: MenuItemWStory = {
+  render: () => (
+    <MenuItemW href="#" active>
+      Liquidity Hub
+    </MenuItemW>
+  ),
+}
+
+export const MenuItemWAllStates: MenuItemWStory = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <MenuItemW href="#">Liquidity Hub</MenuItemW>
+      <MenuItemW
+        href="#"
+        icon={<span className="inline-block size-4 rounded-full bg-periwinkle-300" aria-hidden="true" />}
+      >
+        Liquidity Hub
+      </MenuItemW>
+      <MenuItemW href="#" active>
+        Liquidity Hub (active)
+      </MenuItemW>
+    </div>
+  ),
+}
+
+export const MenuItemWAllStatesDark: MenuItemWStory = {
+  parameters: { backgrounds: { default: 'dark' } },
+  render: () => (
+    <div className="dark bg-bg p-8">
+      <div className="flex flex-col gap-4">
+        <MenuItemW href="#">Liquidity Hub</MenuItemW>
+        <MenuItemW
+          href="#"
+          icon={<span className="inline-block size-4 rounded-full bg-periwinkle-300" aria-hidden="true" />}
+        >
+          Liquidity Hub
+        </MenuItemW>
+        <MenuItemW href="#" active>
+          Liquidity Hub (active)
+        </MenuItemW>
+      </div>
+    </div>
+  ),
+}

--- a/src/components/ui/menu-item.tsx
+++ b/src/components/ui/menu-item.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+type BaseProps = {
+  href?: string
+  active?: boolean
+  className?: string
+  children: React.ReactNode
+}
+
+type AnchorProps = BaseProps & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps>
+type ButtonNativeProps = BaseProps & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>
+
+export type MenuItemProps = AnchorProps | ButtonNativeProps
+
+/**
+ * Uppercase nav link (e.g. header nav items).
+ * - Default: `text-fg`
+ * - Hover: underline + `text-accent-primary`
+ * - Active: underline + bold + `text-accent-primary`
+ *
+ * Renders as an `<a>` when `href` is provided, otherwise a `<button>`.
+ */
+export const MenuItem = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, MenuItemProps>(
+  ({ href, active = false, className, children, ...props }, ref) => {
+    const classes = cn(
+      'inline-flex items-center uppercase text-detail tracking-wide transition-colors',
+      'hover:underline hover:text-accent-primary underline-offset-4',
+      active ? 'underline font-bold text-accent-primary' : 'font-medium text-fg',
+      className
+    )
+
+    if (href !== undefined) {
+      return (
+        <a
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          href={href}
+          aria-current={active ? 'page' : undefined}
+          className={classes}
+          {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+        >
+          {children}
+        </a>
+      )
+    }
+
+    return (
+      <button
+        ref={ref as React.Ref<HTMLButtonElement>}
+        type="button"
+        aria-current={active ? 'page' : undefined}
+        className={classes}
+        {...(props as React.ButtonHTMLAttributes<HTMLButtonElement>)}
+      >
+        {children}
+      </button>
+    )
+  }
+)
+MenuItem.displayName = 'MenuItem'
+
+type MenuItemWBaseProps = BaseProps & {
+  icon?: React.ReactNode
+}
+
+type MenuItemWAnchorProps = MenuItemWBaseProps & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof MenuItemWBaseProps>
+type MenuItemWButtonProps = MenuItemWBaseProps & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof MenuItemWBaseProps>
+
+export type MenuItemWProps = MenuItemWAnchorProps | MenuItemWButtonProps
+
+/**
+ * Title-case menu item with an optional leading icon (e.g. "Liquidity Hub").
+ * - Default: `text-fg`
+ * - Hover: underline + `text-accent-primary`
+ * - Active: underline + `text-accent-primary`
+ */
+export const MenuItemW = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, MenuItemWProps>(
+  ({ href, active = false, icon, className, children, ...props }, ref) => {
+    const classes = cn(
+      'inline-flex items-center gap-2 font-medium text-field transition-colors underline-offset-4',
+      'hover:underline hover:text-accent-primary',
+      active ? 'underline text-accent-primary' : 'text-fg',
+      className
+    )
+
+    const body = (
+      <>
+        {icon ? <span className="inline-flex shrink-0 items-center">{icon}</span> : null}
+        <span>{children}</span>
+      </>
+    )
+
+    if (href !== undefined) {
+      return (
+        <a
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          href={href}
+          aria-current={active ? 'page' : undefined}
+          className={classes}
+          {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+        >
+          {body}
+        </a>
+      )
+    }
+
+    return (
+      <button
+        ref={ref as React.Ref<HTMLButtonElement>}
+        type="button"
+        aria-current={active ? 'page' : undefined}
+        className={classes}
+        {...(props as React.ButtonHTMLAttributes<HTMLButtonElement>)}
+      >
+        {body}
+      </button>
+    )
+  }
+)
+MenuItemW.displayName = 'MenuItemW'

--- a/src/components/ui/secondary-nav-link.stories.tsx
+++ b/src/components/ui/secondary-nav-link.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+
+import { SecondaryNavLink } from './secondary-nav-link'
+
+const meta = {
+  title: 'UI/SecondaryNavLink',
+  component: SecondaryNavLink,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    href: { control: 'text' },
+    active: { control: 'boolean' },
+  },
+  args: {
+    href: '#',
+    children: 'All',
+  },
+} satisfies Meta<typeof SecondaryNavLink>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  args: {
+    active: false,
+  },
+}
+
+export const Active: Story = {
+  args: {
+    active: true,
+  },
+}
+
+export const AllStates: Story = {
+  parameters: { controls: { hideNoControlsWarning: true } },
+  render: () => (
+    <div className="flex items-center gap-6">
+      <SecondaryNavLink href="#">All</SecondaryNavLink>
+      <SecondaryNavLink href="#" active>
+        Products
+      </SecondaryNavLink>
+      <SecondaryNavLink href="#">Developers</SecondaryNavLink>
+    </div>
+  ),
+}
+
+export const AllStatesDark: Story = {
+  parameters: { controls: { hideNoControlsWarning: true }, backgrounds: { default: 'dark' } },
+  render: () => (
+    <div className="dark bg-bg p-8">
+      <div className="flex items-center gap-6">
+        <SecondaryNavLink href="#">All</SecondaryNavLink>
+        <SecondaryNavLink href="#" active>
+          Products
+        </SecondaryNavLink>
+        <SecondaryNavLink href="#">Developers</SecondaryNavLink>
+      </div>
+    </div>
+  ),
+}

--- a/src/components/ui/secondary-nav-link.tsx
+++ b/src/components/ui/secondary-nav-link.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+type BaseProps = {
+  href?: string
+  active?: boolean
+  className?: string
+  children: React.ReactNode
+}
+
+type AnchorProps = BaseProps & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps>
+type ButtonNativeProps = BaseProps & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>
+
+export type SecondaryNavLinkProps = AnchorProps | ButtonNativeProps
+
+/**
+ * Small uppercase nav link (e.g. "ALL" in a sub-nav).
+ * - Default: `text-fg-muted`
+ * - Hover / active: `text-accent-primary`
+ */
+export const SecondaryNavLink = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, SecondaryNavLinkProps>(
+  ({ href, active = false, className, children, ...props }, ref) => {
+    const classes = cn(
+      'inline-flex items-center uppercase font-medium text-detail tracking-wide transition-colors',
+      'hover:text-accent-primary',
+      active ? 'text-accent-primary' : 'text-fg-muted',
+      className
+    )
+
+    if (href !== undefined) {
+      return (
+        <a
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          href={href}
+          aria-current={active ? 'page' : undefined}
+          className={classes}
+          {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+        >
+          {children}
+        </a>
+      )
+    }
+
+    return (
+      <button
+        ref={ref as React.Ref<HTMLButtonElement>}
+        type="button"
+        aria-current={active ? 'page' : undefined}
+        className={classes}
+        {...(props as React.ButtonHTMLAttributes<HTMLButtonElement>)}
+      >
+        {children}
+      </button>
+    )
+  }
+)
+SecondaryNavLink.displayName = 'SecondaryNavLink'


### PR DESCRIPTION
## Summary
- Overhauled `src/components/ui/button.tsx` to Primary/Secondary variants matching the Orbs Figma (bordered, uppercase, arrow, 3 states)
- New primitives: MenuItem, MenuItemW, FooterLink1, FooterLink2, SecondaryNavLink, LargeLink
- Overhauled button stories + stories for every new primitive in light + dark

## Why
Wave 1.2 of the design-system rollout (`docs/design-system-plan.md`). Downstream Wave 2/3 components (Header, Footer, Signup, Cards) all consume these.

## Test plan
- [x] `npm run lint` clean
- [x] `npm test` green
- [x] Homepage button renders with the new style

🤖 Generated with [Claude Code](https://claude.com/claude-code)