### PR TITLE
fix(cn): teach tailwind-merge about custom text-* font sizes

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,21 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from 'clsx'
+import { extendTailwindMerge } from 'tailwind-merge'
+
+/**
+ * tailwind-merge doesn't know about our custom `text-*` font-size utilities
+ * (`text-h1`..`text-h5`, `text-p`, `text-detail`, `text-field`) defined in
+ * `tailwind.config.ts`. Without this hint it classifies them as text colors
+ * and deduplicates them against `text-fg`/`text-fg-muted`/etc., silently
+ * dropping the font-size when both appear in the same className. Extending
+ * the `font-size` class group restores proper merge semantics.
+ */
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      'font-size': [{ text: ['h1', 'h2', 'h3', 'h4', 'h5', 'p', 'detail', 'field'] }],
+    },
+  },
+})
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))


### PR DESCRIPTION
## Summary
- `src/lib/utils.ts`: extend `tailwind-merge` with our custom `text-h1`..`text-h5` / `text-p` / `text-detail` / `text-field` font sizes so they're not deduped against `text-fg`/`text-fg-muted` text colors.

## Why
Spotted during local Wave 1 review: every typography primitive (`H1` through `FieldInput`) was rendering at ~16px in the **UI > Typography** story, while the **Design System > Tokens > Typography** story rendered the correct sizes. Root cause: the components compose with `cn('text-h1 text-fg font-normal', className)`. `tailwind-merge` doesn't recognise `text-h1` as a font-size (only default `text-xs`..`text-9xl`), so it lumps `text-h1` and `text-fg` into the same class group and keeps only the later one (`text-fg`). The font-size was being silently stripped.

The tokens story worked because it applied classes directly without `cn()`, so the merge step never ran.

## Test plan
- [x] Verified computed font-size of each heading in Storybook matches the token value (H2=56px, H3=32px, H4=22px, H5=14px, etc.) via Playwright
- [x] Visually confirmed in the `UI > Typography > All` story
- [x] `npm run lint` clean
- [x] `npm test` 61/61 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)