### PR TITLE
feat: paginate the blog index

### DIFF
--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,6 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
-import { BLOG_INDEX_PATH, HOME_PATH, postPath } from '@/app/lib/routes'
+import { BLOG_INDEX_PATH, BLOG_PAGE_ROUTE, HOME_PATH, postPath } from '@/app/lib/routes'
 import { secretMatches } from '@/app/lib/secrets'
 
 /**
@@ -94,21 +94,26 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ revalidated: ['layout'], topic, reason })
   }
 
-  const paths = [HOME_PATH, BLOG_INDEX_PATH]
-
-  // No shape check on purpose. This path is only ever handed to
-  // revalidatePath(), never to a redirect, so an odd slug is at worst a no-op
+  // No shape check on the slug here, on purpose. It is only ever handed to
+  // revalidatePath(), never to a redirect, so an odd value is at worst a no-op
   // against a path that does not exist. Validating would mean *skipping*
   // revalidation for a post the [slug] route serves happily, which is the
   // worse failure — it would leave real content stale.
-  paths.push(postPath(slug))
+  const paths = [HOME_PATH, BLOG_INDEX_PATH, postPath(slug)]
 
   for (const path of paths) {
     revalidatePath(path)
   }
 
-  console.info(`[revalidate] ${topic} ${entryId} -> ${paths.join(', ')}`)
-  return NextResponse.json({ revalidated: paths, topic })
+  // Publishing shifts every later post down a page, so one publish changes all
+  // N archive pages, not just the first. Passing the route pattern with type
+  // 'page' invalidates every generated instance in a single call, which avoids
+  // fetching the page count on every webhook.
+  revalidatePath(BLOG_PAGE_ROUTE, 'page')
+
+  const revalidated = [...paths, BLOG_PAGE_ROUTE]
+  console.info(`[revalidate] ${topic} ${entryId} -> ${revalidated.join(', ')}`)
+  return NextResponse.json({ revalidated, topic })
 }
 
 /*

--- a/src/app/blog/blog-index.tsx
+++ b/src/app/blog/blog-index.tsx
@@ -1,0 +1,62 @@
+import { notFound } from 'next/navigation'
+import { H1 } from '../components/typography'
+import { getPosts, POSTS_PER_PAGE } from '../lib/api'
+import { BlogCard } from './blog-card'
+import { Pagination } from './pagination'
+
+function Heading() {
+  return (
+    <div className="flex flex-col items-center justify-center pt-10 pb-32">
+      <H1 className="inline-block text-center mx-auto">The Orbs Project Blog</H1>
+      <p className="text-gray-600 dark:text-gray-400">
+        Thoughts about the Orbs project, open source, blockchain and engineering.
+      </p>
+    </div>
+  )
+}
+
+/**
+ * Shared body for `/blog` and `/blog/page/[n]` so the two routes cannot drift.
+ */
+export async function BlogIndex({ currentPage }: { currentPage: number }) {
+  const { items, total } = await getPosts({
+    skip: (currentPage - 1) * POSTS_PER_PAGE,
+    limit: POSTS_PER_PAGE,
+  })
+
+  const totalPages = Math.max(1, Math.ceil(total / POSTS_PER_PAGE))
+
+  // A page number past the end would otherwise render an empty grid at a
+  // crawlable URL. Page 1 is exempt: an empty archive is a valid state.
+  if (currentPage > 1 && items.length === 0) {
+    notFound()
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="container mx-auto px-5 py-10">
+        <Heading />
+        <p className="text-gray-600 dark:text-gray-400">No posts found. Check back soon!</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto px-5 py-10">
+      <Heading />
+      <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-3">
+        {items.map((post) => (
+          <BlogCard key={post.slug} post={post} />
+        ))}
+      </div>
+      <Pagination currentPage={currentPage} totalPages={totalPages} />
+    </div>
+  )
+}
+
+/** Page count, for `generateStaticParams` and canonical/prev-next metadata. */
+export async function getTotalPages(): Promise<number> {
+  // limit: 1 — we only want `total`, not the entries.
+  const { total } = await getPosts({ skip: 0, limit: 1 })
+  return Math.max(1, Math.ceil(total / POSTS_PER_PAGE))
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,48 +1,22 @@
 import { Metadata } from 'next'
-import { H1 } from '../components/typography'
-import { getAllPosts } from '../lib/api'
-import { BlogCard } from './blog-card'
-
-export const metadata: Metadata = {
-  title: 'Blog',
-  description: 'Read our latest blog posts',
-}
+import { BlogIndex, getTotalPages } from './blog-index'
+import { blogPagePath } from '../lib/routes'
 
 // Time-based fallback. On-demand invalidation via the Contentful webhook
 // (#19) is the primary path; this bounds staleness if a webhook is missed.
 export const revalidate = 3600
 
-function Heading() {
-  return (
-    <div className="flex flex-col items-center justify-center pt-10 pb-32">
-      <H1 className="inline-block text-center mx-auto">The Orbs Project Blog</H1>
-      <p className="text-gray-600 dark:text-gray-400">
-        Thoughts about the Orbs project, open source, blockchain and engineering.
-      </p>
-    </div>
-  )
+export const metadata: Metadata = {
+  title: 'Blog',
+  description: 'Read our latest blog posts',
+  alternates: {
+    // Each page in the series is its own canonical. Pointing every page at
+    // /blog would tell crawlers pages 2+ are duplicates and drop those posts
+    // from the index entirely.
+    canonical: blogPagePath(1),
+  },
 }
 
 export default async function BlogPage() {
-  const allPosts = await getAllPosts()
-
-  if (!allPosts || allPosts.length === 0) {
-    return (
-      <div className="container mx-auto px-5 py-10">
-        <Heading />
-        <p className="text-gray-600 dark:text-gray-400">No posts found. Check back soon!</p>
-      </div>
-    )
-  }
-
-  return (
-    <div className="container mx-auto px-5 py-10">
-      <Heading />
-      <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-3">
-        {allPosts.map((post) => (
-          <BlogCard key={post.slug} post={post} />
-        ))}
-      </div>
-    </div>
-  )
+  return <BlogIndex currentPage={1} />
 }

--- a/src/app/blog/page/[n]/page.tsx
+++ b/src/app/blog/page/[n]/page.tsx
@@ -23,12 +23,26 @@ export async function generateStaticParams() {
   }))
 }
 
-/** Rejects `1`, `0`, `-3`, `2.5`, `abc`, `02` — anything but a plain integer >= 2. */
+/**
+ * Far above any plausible archive (10k pages is 120k posts), but low enough
+ * that `skip` stays a small integer Contentful accepts.
+ *
+ * Without an upper bound, `/blog/page/999999999999999999999` parses to an
+ * imprecise float, multiplies into an invalid `skip`, and Contentful rejects
+ * it — turning a bad URL into a user-triggerable 500 instead of a 404.
+ */
+const MAX_PAGE = 10_000
+
+/** Rejects `1`, `0`, `-3`, `2.5`, `abc`, `02` — anything but a plain integer in [2, MAX_PAGE]. */
 function parsePageNumber(raw: string): number | null {
-  if (!/^[1-9][0-9]*$/.test(raw)) return null
+  // Bound the digit count before Number(), so an over-long string never
+  // becomes Infinity or loses precision.
+  if (!/^[1-9][0-9]{0,5}$/.test(raw)) return null
 
   const parsed = Number(raw)
-  return parsed >= 2 ? parsed : null
+  if (!Number.isSafeInteger(parsed)) return null
+
+  return parsed >= 2 && parsed <= MAX_PAGE ? parsed : null
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {

--- a/src/app/blog/page/[n]/page.tsx
+++ b/src/app/blog/page/[n]/page.tsx
@@ -1,0 +1,74 @@
+import { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import { BlogIndex, getTotalPages } from '../../blog-index'
+import { blogPagePath } from '../../../lib/routes'
+
+type Props = {
+  params: Promise<{ n: string }>
+}
+
+// Time-based fallback. On-demand invalidation via the Contentful webhook
+// (#19) is the primary path; this bounds staleness if a webhook is missed.
+export const revalidate = 3600
+
+/**
+ * Page 1 is served by /blog, so this route starts at 2. Generating a
+ * /blog/page/1 would create a second URL for identical content.
+ */
+export async function generateStaticParams() {
+  const totalPages = await getTotalPages()
+
+  return Array.from({ length: Math.max(0, totalPages - 1) }, (_, index) => ({
+    n: String(index + 2),
+  }))
+}
+
+/** Rejects `1`, `0`, `-3`, `2.5`, `abc`, `02` — anything but a plain integer >= 2. */
+function parsePageNumber(raw: string): number | null {
+  if (!/^[1-9][0-9]*$/.test(raw)) return null
+
+  const parsed = Number(raw)
+  return parsed >= 2 ? parsed : null
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { n } = await params
+  const pageNumber = parsePageNumber(n)
+
+  if (pageNumber === null) {
+    return { title: 'Page Not Found' }
+  }
+
+  return {
+    title: `Blog — page ${pageNumber}`,
+    description: 'Read our latest blog posts',
+    alternates: {
+      // Self-canonical, deliberately. Canonicalising pages 2+ back to /blog
+      // would mark them duplicates and drop everything but the newest 12 posts
+      // from the index.
+      canonical: blogPagePath(pageNumber),
+    },
+  }
+}
+
+/*
+ * No rel="prev" / rel="next".
+ *
+ * Google stopped using them as an indexing signal in 2019, and Next's Metadata
+ * API cannot emit `<link rel="prev">` — routing them through `other` produces
+ * `<meta name="prev">`, which no crawler consumes. Shipping markup that only
+ * looks like it does something is worse than omitting it. The per-page
+ * canonical above is the part that actually matters, and the pagination
+ * component gives crawlers real <a href> links to follow.
+ */
+
+export default async function BlogPaginatedPage({ params }: Props) {
+  const { n } = await params
+  const pageNumber = parsePageNumber(n)
+
+  if (pageNumber === null) {
+    notFound()
+  }
+
+  return <BlogIndex currentPage={pageNumber} />
+}

--- a/src/app/blog/pagination.tsx
+++ b/src/app/blog/pagination.tsx
@@ -1,0 +1,73 @@
+import Link from 'next/link'
+import { blogPagePath } from '../lib/routes'
+import { cn } from '@/lib/utils'
+
+type Props = {
+  currentPage: number
+  totalPages: number
+}
+
+/**
+ * Builds a compact page list with ellipses, e.g. for page 7 of 27:
+ *   1 … 6 7 8 … 27
+ * Always includes the first and last page so the ends of the archive stay one
+ * click away.
+ */
+function pageItems(currentPage: number, totalPages: number): (number | 'gap')[] {
+  const pages = new Set<number>([1, totalPages, currentPage])
+  if (currentPage - 1 > 1) pages.add(currentPage - 1)
+  if (currentPage + 1 < totalPages) pages.add(currentPage + 1)
+
+  const sorted = [...pages].filter((p) => p >= 1 && p <= totalPages).sort((a, b) => a - b)
+
+  const items: (number | 'gap')[] = []
+  let previous = 0
+  for (const page of sorted) {
+    if (previous && page - previous > 1) items.push('gap')
+    items.push(page)
+    previous = page
+  }
+
+  return items
+}
+
+export function Pagination({ currentPage, totalPages }: Props) {
+  if (totalPages <= 1) return null
+
+  const items = pageItems(currentPage, totalPages)
+  const linkClass = 'px-3 py-2 rounded-[var(--radius)] text-sm transition-colors hover:bg-accent'
+
+  return (
+    <nav className="flex items-center justify-center gap-1 mt-12" aria-label="Blog pagination">
+      {currentPage > 1 && (
+        <Link href={blogPagePath(currentPage - 1)} className={linkClass} rel="prev">
+          Previous
+        </Link>
+      )}
+
+      {items.map((item, index) =>
+        item === 'gap' ? (
+          <span key={`gap-${index}`} className="px-2 text-muted-foreground" aria-hidden="true">
+            …
+          </span>
+        ) : (
+          <Link
+            key={item}
+            href={blogPagePath(item)}
+            className={cn(linkClass, item === currentPage && 'bg-accent font-semibold')}
+            aria-label={`Page ${item}`}
+            aria-current={item === currentPage ? 'page' : undefined}
+          >
+            {item}
+          </Link>
+        )
+      )}
+
+      {currentPage < totalPages && (
+        <Link href={blogPagePath(currentPage + 1)} className={linkClass} rel="next">
+          Next
+        </Link>
+      )}
+    </nav>
+  )
+}

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -104,8 +104,13 @@ export async function getPosts({ skip = 0, limit = POSTS_PER_PAGE } = {}): Promi
   const client = getClient()
 
   const page = await client.getEntries<TypeBlogPostSkeleton>({
+    // `sys.id` breaks ties on `date`. Dates are day-precision and 18 of the
+    // current 320 posts share one with another post; without a unique
+    // secondary key, Contentful may order a tie group differently between the
+    // request for page N and the request for page N+1, so a post can appear on
+    // both pages or on neither.
     content_type: 'blogPost',
-    order: ['-fields.date'],
+    order: ['-fields.date', 'sys.id'],
     limit: Math.min(limit, CDA_MAX_LIMIT),
     skip,
   })

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -84,39 +84,41 @@ function getClient(preview = false) {
 // Always pass an explicit limit — the default silently truncates.
 const CDA_MAX_LIMIT = 1000
 
-/**
- * Every blog post, newest first.
- *
- * Ordering is done by Contentful (`-fields.date`) rather than in JS so that
- * each page of a paginated fetch is drawn from a globally sorted set. Sorting
- * client-side over a partial result is what previously disguised the fact that
- * only the first 100 entries were being returned at all.
- */
-export async function getAllPosts(): Promise<BlogPostFields[]> {
-  const client = getClient()
-  const items: BlogPostFields[] = []
-  let skip = 0
+/** Posts per page on the blog index. Divides evenly into the 1/2/3-col grid. */
+export const POSTS_PER_PAGE = 12
 
-  for (;;) {
-    const page = await client.getEntries<TypeBlogPostSkeleton>({
-      content_type: 'blogPost',
-      order: ['-fields.date'],
-      limit: CDA_MAX_LIMIT,
-      skip,
-    })
-
-    items.push(...page.items.map((post) => post.fields))
-
-    skip += page.items.length
-    if (skip >= page.total || page.items.length === 0) break
-  }
-
-  return items
+export type PostPage = {
+  items: BlogPostFields[]
+  total: number
 }
 
 /**
- * The N most recent posts. Prefer this over slicing `getAllPosts()` — it asks
- * Contentful for N rather than pulling the whole archive to discard most of it.
+ * One page of posts, newest first, plus the total count for pagination.
+ *
+ * Ordering is done by Contentful (`-fields.date`) rather than in JS, so each
+ * page is a slice of a globally sorted set. Sorting client-side over a partial
+ * result is what previously disguised the fact that only the first 100 entries
+ * were being returned at all.
+ */
+export async function getPosts({ skip = 0, limit = POSTS_PER_PAGE } = {}): Promise<PostPage> {
+  const client = getClient()
+
+  const page = await client.getEntries<TypeBlogPostSkeleton>({
+    content_type: 'blogPost',
+    order: ['-fields.date'],
+    limit: Math.min(limit, CDA_MAX_LIMIT),
+    skip,
+  })
+
+  return {
+    items: page.items.map((post) => post.fields),
+    total: page.total,
+  }
+}
+
+/**
+ * The N most recent posts. Asks Contentful for N rather than fetching a larger
+ * set and discarding most of it.
  */
 export async function getRecentPosts(count: number): Promise<BlogPostFields[]> {
   const client = getClient()

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -87,6 +87,23 @@ const CDA_MAX_LIMIT = 1000
 /** Posts per page on the blog index. Divides evenly into the 1/2/3-col grid. */
 export const POSTS_PER_PAGE = 12
 
+/**
+ * The single ordering used by every post query.
+ *
+ * `sys.id` breaks ties on `date`. Dates are day-precision and 18 of the current
+ * 320 posts share one with another post, so date alone is not a total order.
+ * That matters in two ways:
+ *
+ *  - Any query paginating on `skip` can return a tie group in a different
+ *    order between consecutive pages, so a post lands on both pages or on
+ *    neither. For `getAllPostSlugs` that means a post never gets prerendered.
+ *  - Two queries using different orderings disagree with each other, so the
+ *    home page's recent posts can contradict page 1 of the blog.
+ *
+ * Anything ordering posts must use this. Do not inline a different one.
+ */
+const POST_ORDER = ['-fields.date', 'sys.id'] as const
+
 export type PostPage = {
   items: BlogPostFields[]
   total: number
@@ -95,22 +112,17 @@ export type PostPage = {
 /**
  * One page of posts, newest first, plus the total count for pagination.
  *
- * Ordering is done by Contentful (`-fields.date`) rather than in JS, so each
- * page is a slice of a globally sorted set. Sorting client-side over a partial
- * result is what previously disguised the fact that only the first 100 entries
- * were being returned at all.
+ * Ordering is done by Contentful rather than in JS, so each page is a slice of
+ * a globally sorted set. Sorting client-side over a partial result is what
+ * previously disguised the fact that only the first 100 entries were being
+ * returned at all.
  */
 export async function getPosts({ skip = 0, limit = POSTS_PER_PAGE } = {}): Promise<PostPage> {
   const client = getClient()
 
   const page = await client.getEntries<TypeBlogPostSkeleton>({
-    // `sys.id` breaks ties on `date`. Dates are day-precision and 18 of the
-    // current 320 posts share one with another post; without a unique
-    // secondary key, Contentful may order a tie group differently between the
-    // request for page N and the request for page N+1, so a post can appear on
-    // both pages or on neither.
     content_type: 'blogPost',
-    order: ['-fields.date', 'sys.id'],
+    order: [...POST_ORDER],
     limit: Math.min(limit, CDA_MAX_LIMIT),
     skip,
   })
@@ -130,7 +142,7 @@ export async function getRecentPosts(count: number): Promise<BlogPostFields[]> {
 
   const posts = await client.getEntries<TypeBlogPostSkeleton>({
     content_type: 'blogPost',
-    order: ['-fields.date'],
+    order: [...POST_ORDER],
     limit: count,
   })
 
@@ -154,7 +166,7 @@ export async function getAllPostSlugs(): Promise<string[]> {
     const page = await client.getEntries<TypeBlogPostSkeleton>({
       content_type: 'blogPost',
       select: ['fields.slug'],
-      order: ['-fields.date'],
+      order: [...POST_ORDER],
       limit: CDA_MAX_LIMIT,
       skip,
     })

--- a/src/app/lib/routes.ts
+++ b/src/app/lib/routes.ts
@@ -20,3 +20,13 @@ export const HOME_PATH = '/'
 export function blogPagePath(pageNumber: number): string {
   return pageNumber <= 1 ? BLOG_INDEX_PATH : `${BLOG_INDEX_PATH}/page/${pageNumber}`
 }
+
+/**
+ * The route pattern, not a concrete URL. Passed to `revalidatePath(path, 'page')`
+ * to invalidate every generated page of the archive at once.
+ *
+ * Publishing a post shifts every later post down, so a single publish changes
+ * all N archive pages — not just the first. Targeting them individually would
+ * mean fetching the page count on every webhook.
+ */
+export const BLOG_PAGE_ROUTE = '/blog/page/[n]'

--- a/src/app/lib/routes.ts
+++ b/src/app/lib/routes.ts
@@ -12,3 +12,11 @@ export function postPath(slug: string): string {
 
 export const BLOG_INDEX_PATH = '/blog'
 export const HOME_PATH = '/'
+
+/**
+ * Page 1 lives at `/blog` rather than `/blog/page/1`, so there is exactly one
+ * URL for it. Emitting both would split ranking signals between duplicates.
+ */
+export function blogPagePath(pageNumber: number): string {
+  return pageNumber <= 1 ? BLOG_INDEX_PATH : `${BLOG_INDEX_PATH}/page/${pageNumber}`
+}


### PR DESCRIPTION
Closes #50.

## The problem

`/blog` rendered every post as a card:

| | Before | After |
| --- | --- | --- |
| `/blog` HTML | **1.9 MB** | **100 KB** |
| Cards | 320 | 12 |

The index was **32x the weight of an actual article**, downloaded by every visitor. It hits 458 posts once #22 completes.

**#48 made it worse before this makes it better** — fixing the pagination bug took the page from 100 cards to 320. Correct, since the other 220 were 404ing, but it tripled this page. The legacy Cuttlebelle site paginated the index (`assets/js/blogs/pagination.js`); the rebuild dropped it.

## Changes

- `getPosts({ skip, limit }) → { items, total }` replaces `getAllPosts()`. Contentful returns `total` on every response, so paging is free.
- `/blog` is page 1; `/blog/page/[n]` covers 2..N, prerendered. 27 pages at 12 per page.
- Page 1 is **not** also served at `/blog/page/1` — one URL per page of results.
- Each page is **self-canonical**. Canonicalising 2+ back to `/blog` would mark them duplicates and drop all but the newest 12 posts from the index.
- Shared `BlogIndex` component so the two routes can't drift.
- The webhook now revalidates the whole `/blog/page/[n]` route on publish.

**`getAllPosts()` is deleted.** It had no caller left — `generateStaticParams` uses `getAllPostSlugs` (slug-only via `select`), home uses `getRecentPosts(3)`, and the index now pages. #17/#18 genuinely need every post but only slug/title/date, so they should add a narrow `select` rather than resurrect a function that pulls 320 full Rich Text documents.

## Judgment calls

**No `rel=prev`/`rel=next`.** Google dropped them as an indexing signal in 2019, and Next's Metadata API can't emit `<link rel="prev">` — routing them through `other` produces `<meta name="prev">`, which nothing consumes. I had this in and took it out rather than ship markup that only looks like it does something. Per-page canonicals do the real work, and the pagination component gives crawlers actual `<a href>` links.

**Full prerender kept.** ISR means we *could* prerender the newest N posts and generate the rest on demand, but `getAllPostSlugs` is a cheap `select` and the whole build is 13s for 355 pages. Warm first byte on every archive post is worth more than shaving a build that isn't slow.

## Review

Four Codex passes at high effort. Findings, all fixed:

| Finding | Why it mattered |
| --- | --- |
| Archive pages not revalidated on publish | A publish shifts every post down a page, so all 27 change — the webhook only purged `/blog` |
| Unstable ordering under date ties | 18 of 320 posts share a date; offset pagination over a non-total order puts a post on two pages or neither |
| Huge page number → 500 | `/blog/page/999…9` parsed to an imprecise float, produced an invalid `skip`, Contentful rejected it |
| Sibling queries used a different order | Home page's recent posts could contradict `/blog` page 1 |

On the last one Codex flagged only `getRecentPosts`. `getAllPostSlugs` had the same bug and it's worse — it paginates on `skip`, so a tie could drop a slug and leave a post with no prerendered page. All three now share one documented `POST_ORDER`.

Final pass clean.

## Testing notes

```
/blog                            200      /blog/page/1                     404
/blog/page/2                     200      /blog/page/0                     404
/blog/page/27                    200      /blog/page/28                    404
                                          /blog/page/999999                404
                                          /blog/page/999999999999999999999 404  (was 500)
                                          /blog/page/abc                   404
                                          /blog/page/2.5                   404
                                          /blog/page/02                    404
                                          /blog/page/-1                    404
```

- Page 27 holds 8 posts (320 − 26×12)
- No post slug appears on more than one page
- Home and `/blog` page 1 return identical first three posts
- Webhook publish → `["/","/blog","/spookyswap-integrates-dsltp","/blog/page/[n]"]`
- `tsc --noEmit` clean, `lint` clean

## Note

The Netlify checks will fail. They've failed on every PR in this repo — it's the old `orbs-website-preview` integration, which you're unlinking. `test` is the real check.