### PR TITLE
feat: add sitemap.xml and robots.txt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,12 +16,12 @@ CONTENTFUL_REVALIDATE_SECRET=
 
 # Canonical origin for absolute URLs in sitemap.xml and robots.txt.
 # Optional — defaults to https://www.orbs.com.
-NEXT_PUBLIC_SITE_URL=
+SITE_URL=
 
 # Force robots.txt to allow or block indexing, overriding the environment
 # check. Rarely needed — set to "false" to block a production-like deployment,
 # or "true" to index one that isn't detected as production.
-NEXT_PUBLIC_ALLOW_INDEXING=
+ALLOW_INDEXING=
 
 # Optional, defaults to en-US. Must match the space's locale — webhook payloads
 # key field values by locale.

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,11 @@ CONTENTFUL_REVALIDATE_SECRET=
 # Optional — defaults to https://www.orbs.com.
 NEXT_PUBLIC_SITE_URL=
 
+# Force robots.txt to allow or block indexing, overriding the environment
+# check. Rarely needed — set to "false" to block a production-like deployment,
+# or "true" to index one that isn't detected as production.
+NEXT_PUBLIC_ALLOW_INDEXING=
+
 # Optional, defaults to en-US. Must match the space's locale — webhook payloads
 # key field values by locale.
 CONTENTFUL_LOCALE=

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ CONTENTFUL_PREVIEW_ACCESS_TOKEN=
 CONTENTFUL_PREVIEW_SECRET=
 CONTENTFUL_REVALIDATE_SECRET=
 
+# Canonical origin for absolute URLs in sitemap.xml and robots.txt.
+# Optional — defaults to https://www.orbs.com.
+NEXT_PUBLIC_SITE_URL=
+
 # Optional, defaults to en-US. Must match the space's locale — webhook payloads
 # key field values by locale.
 CONTENTFUL_LOCALE=

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -9,6 +9,8 @@ import type { ReactNode } from 'react'
 import { Author } from '../components/blog/author'
 import { H4 } from '../components/typography'
 import { getAllPostSlugs, getAssetUrl, getAuthorInfo, getPostBySlug } from '../lib/api'
+import { postPath } from '../lib/routes'
+import { absoluteUrl } from '../lib/site'
 import { BackButton } from './back-button'
 
 // Helper to unwrap paragraph from list item children
@@ -128,6 +130,12 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title: post.title,
     description: post.shortDescription || '',
+    alternates: {
+      // Absolute, matching the sitemap. A relative canonical resolves against
+      // the request host, so a post served from a Vercel alias would
+      // self-canonicalize that hostname and compete with the real domain.
+      canonical: absoluteUrl(postPath(slug)),
+    },
   }
 }
 

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,6 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
-import { BLOG_INDEX_PATH, BLOG_PAGE_ROUTE, HOME_PATH, postPath, postRedirectPath } from '@/app/lib/routes'
+import { BLOG_INDEX_PATH, BLOG_PAGE_ROUTE, HOME_PATH, SITEMAP_PATH, postPath, postRedirectPath } from '@/app/lib/routes'
 import { secretMatches } from '@/app/lib/secrets'
 
 /**
@@ -118,7 +118,7 @@ export async function POST(request: NextRequest) {
   // one, and it cannot be settled by testing — 0 of the 320 slugs in the space
   // are non-ASCII, so no such page exists to observe. Sending both costs one
   // no-op call and removes the need to guess. Revisit once #22 lands those two.
-  const paths = [...new Set([HOME_PATH, BLOG_INDEX_PATH, postPath(slug), postRedirectPath(slug)])]
+  const paths = [...new Set([HOME_PATH, BLOG_INDEX_PATH, SITEMAP_PATH, postPath(slug), postRedirectPath(slug)])]
 
   for (const path of paths) {
     revalidatePath(path)

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,6 +1,6 @@
 import { revalidatePath } from 'next/cache'
 import { NextRequest, NextResponse } from 'next/server'
-import { BLOG_INDEX_PATH, BLOG_PAGE_ROUTE, HOME_PATH, SITEMAP_PATH, postPath, postRedirectPath } from '@/app/lib/routes'
+import { BLOG_INDEX_PATH, BLOG_PAGE_ROUTE, HOME_PATH, postPath, postRedirectPath } from '@/app/lib/routes'
 import { secretMatches } from '@/app/lib/secrets'
 
 /**
@@ -118,7 +118,7 @@ export async function POST(request: NextRequest) {
   // one, and it cannot be settled by testing — 0 of the 320 slugs in the space
   // are non-ASCII, so no such page exists to observe. Sending both costs one
   // no-op call and removes the need to guess. Revisit once #22 lands those two.
-  const paths = [...new Set([HOME_PATH, BLOG_INDEX_PATH, SITEMAP_PATH, postPath(slug), postRedirectPath(slug)])]
+  const paths = [...new Set([HOME_PATH, BLOG_INDEX_PATH, postPath(slug), postRedirectPath(slug)])]
 
   for (const path of paths) {
     revalidatePath(path)

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next'
 import { BlogIndex, getTotalPages } from './blog-index'
 import { blogPagePath } from '../lib/routes'
+import { absoluteUrl } from '../lib/site'
 
 // Time-based fallback. On-demand invalidation via the Contentful webhook
 // (#19) is the primary path; this bounds staleness if a webhook is missed.
@@ -13,7 +14,7 @@ export const metadata: Metadata = {
     // Each page in the series is its own canonical. Pointing every page at
     // /blog would tell crawlers pages 2+ are duplicates and drop those posts
     // from the index entirely.
-    canonical: blogPagePath(1),
+    canonical: absoluteUrl(blogPagePath(1)),
   },
 }
 

--- a/src/app/blog/page/[n]/page.tsx
+++ b/src/app/blog/page/[n]/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import { BlogIndex, getTotalPages } from '../../blog-index'
 import { blogPagePath } from '../../../lib/routes'
+import { absoluteUrl } from '../../../lib/site'
 
 type Props = {
   params: Promise<{ n: string }>
@@ -60,7 +61,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       // Self-canonical, deliberately. Canonicalising pages 2+ back to /blog
       // would mark them duplicates and drop everything but the newest 12 posts
       // from the index.
-      canonical: blogPagePath(pageNumber),
+      canonical: absoluteUrl(blogPagePath(pageNumber)),
     },
   }
 }

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -151,7 +151,14 @@ export async function getRecentPosts(count: number): Promise<BlogPostFields[]> {
 
 export type PostRef = {
   slug: string
+  /** Publish date, from the content model. Drives ordering and display. */
   date: string
+  /**
+   * Last modification, from Contentful's sys metadata. Distinct from `date`:
+   * editing a published article does not move its publish date, so `date` would
+   * make <lastmod> permanently wrong for every post that is ever corrected.
+   */
+  updatedAt: string
 }
 
 /**
@@ -170,7 +177,7 @@ export async function getAllPostRefs(): Promise<PostRef[]> {
   for (;;) {
     const page = await client.getEntries<TypeBlogPostSkeleton>({
       content_type: 'blogPost',
-      select: ['fields.slug', 'fields.date'],
+      select: ['fields.slug', 'fields.date', 'sys.updatedAt'],
       order: [...POST_ORDER],
       limit: CDA_MAX_LIMIT,
       skip,
@@ -178,7 +185,11 @@ export async function getAllPostRefs(): Promise<PostRef[]> {
 
     for (const post of page.items) {
       if (post.fields.slug) {
-        refs.push({ slug: post.fields.slug, date: post.fields.date })
+        refs.push({
+          slug: post.fields.slug,
+          date: post.fields.date,
+          updatedAt: post.sys.updatedAt || post.fields.date,
+        })
       }
     }
 

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -149,37 +149,49 @@ export async function getRecentPosts(count: number): Promise<BlogPostFields[]> {
   return posts.items.map((post) => post.fields)
 }
 
+export type PostRef = {
+  slug: string
+  date: string
+}
+
 /**
- * Slugs only, for `generateStaticParams()`.
+ * Every post as `{ slug, date }`, newest first.
  *
- * Uses `select` so Contentful returns just the slug field instead of every
- * post's full Rich Text body — the route only needs the slugs to enumerate
- * paths, and fetching complete documents for that is a large build-time cost
- * that grows with the archive.
+ * Uses `select` so Contentful returns two fields rather than each post's full
+ * Rich Text body. Callers here enumerate the archive — `generateStaticParams()`
+ * and the sitemap — and fetching ~460 complete documents for a list of URLs is
+ * a build-time cost that grows with the archive for no benefit.
  */
-export async function getAllPostSlugs(): Promise<string[]> {
+export async function getAllPostRefs(): Promise<PostRef[]> {
   const client = getClient()
-  const slugs: string[] = []
+  const refs: PostRef[] = []
   let skip = 0
 
   for (;;) {
     const page = await client.getEntries<TypeBlogPostSkeleton>({
       content_type: 'blogPost',
-      select: ['fields.slug'],
+      select: ['fields.slug', 'fields.date'],
       order: [...POST_ORDER],
       limit: CDA_MAX_LIMIT,
       skip,
     })
 
     for (const post of page.items) {
-      if (post.fields.slug) slugs.push(post.fields.slug)
+      if (post.fields.slug) {
+        refs.push({ slug: post.fields.slug, date: post.fields.date })
+      }
     }
 
     skip += page.items.length
     if (skip >= page.total || page.items.length === 0) break
   }
 
-  return slugs
+  return refs
+}
+
+/** Slugs only, for `generateStaticParams()`. */
+export async function getAllPostSlugs(): Promise<string[]> {
+  return (await getAllPostRefs()).map((ref) => ref.slug)
 }
 
 /**

--- a/src/app/lib/routes.ts
+++ b/src/app/lib/routes.ts
@@ -54,3 +54,10 @@ export function blogPagePath(pageNumber: number): string {
  * mean fetching the page count on every webhook.
  */
 export const BLOG_PAGE_ROUTE = '/blog/page/[n]'
+
+/**
+ * Not under trailingSlash — it is a file, not a page route.
+ * Publishing changes the set of URLs, so the webhook has to invalidate it or a
+ * new post stays absent from the sitemap until the 1h ISR window expires.
+ */
+export const SITEMAP_PATH = '/sitemap.xml'

--- a/src/app/lib/routes.ts
+++ b/src/app/lib/routes.ts
@@ -57,7 +57,8 @@ export const BLOG_PAGE_ROUTE = '/blog/page/[n]'
 
 /**
  * Not under trailingSlash — it is a file, not a page route.
- * Publishing changes the set of URLs, so the webhook has to invalidate it or a
- * new post stays absent from the sitemap until the 1h ISR window expires.
+ *
+ * The sitemap route is force-dynamic, so it needs no revalidation. Kept because
+ * robots.txt advertises it and one definition beats two string literals.
  */
 export const SITEMAP_PATH = '/sitemap.xml'

--- a/src/app/lib/site.ts
+++ b/src/app/lib/site.ts
@@ -14,8 +14,14 @@ const FALLBACK_SITE_URL = 'https://www.orbs.com'
 /**
  * Origin without a trailing slash. Paths from `lib/routes` supply their own
  * leading slash, and carry a trailing one to match `trailingSlash: true`.
+ *
+ * Deliberately NOT prefixed NEXT_PUBLIC_. That prefix is what makes Next inline
+ * a value at build time, which would freeze the origin into the prerendered
+ * metadata routes — so a build promoted to another environment would keep
+ * serving the previous one's URLs. These routes are server-only, so a plain
+ * server env var is both correct and read at runtime.
  */
-export const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || FALLBACK_SITE_URL).replace(/\/+$/, '')
+export const siteUrl = (process.env.SITE_URL || FALLBACK_SITE_URL).replace(/\/+$/, '')
 
 /** Hostname only — the robots.txt `Host` directive takes no scheme or path. */
 export const siteHost = new URL(siteUrl).host
@@ -32,8 +38,8 @@ export const siteHost = new URL(siteUrl).host
  * So: block what we can positively identify as non-production, allow the rest,
  * and provide an explicit override for cases neither rule fits.
  */
-export const shouldAllowIndexing = (() => {
-  const override = process.env.NEXT_PUBLIC_ALLOW_INDEXING
+export function shouldAllowIndexing(): boolean {
+  const override = process.env.ALLOW_INDEXING
   if (override === 'true') return true
   if (override === 'false') return false
 
@@ -43,7 +49,7 @@ export const shouldAllowIndexing = (() => {
   // Not on Vercel. Trust NODE_ENV, so a self-hosted production build indexes
   // and a local dev server does not.
   return process.env.NODE_ENV === 'production'
-})()
+}
 
 export function absoluteUrl(path: string): string {
   return `${siteUrl}${path.startsWith('/') ? path : `/${path}`}`

--- a/src/app/lib/site.ts
+++ b/src/app/lib/site.ts
@@ -1,0 +1,27 @@
+/**
+ * Canonical origin, and whether this deployment is the real one.
+ *
+ * Vercel sets VERCEL_ENV to production | preview | development, and gives every
+ * deployment its own *.vercel.app hostname. Both matter for SEO:
+ *
+ *  - Absolute URLs in the sitemap must point at the canonical domain, not at
+ *    whatever ephemeral hostname built them.
+ *  - Preview deployments must not be indexed at all. A crawlable preview is the
+ *    same content on a second domain, which is duplicate content competing with
+ *    the real site.
+ */
+
+const FALLBACK_SITE_URL = 'https://www.orbs.com'
+
+/** True only on a Vercel production deployment. */
+export const isProductionDeployment = process.env.VERCEL_ENV === 'production'
+
+/**
+ * Origin without a trailing slash. Paths from `lib/routes` supply their own
+ * leading slash, and carry a trailing one to match `trailingSlash: true`.
+ */
+export const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || FALLBACK_SITE_URL).replace(/\/+$/, '')
+
+export function absoluteUrl(path: string): string {
+  return `${siteUrl}${path.startsWith('/') ? path : `/${path}`}`
+}

--- a/src/app/lib/site.ts
+++ b/src/app/lib/site.ts
@@ -1,26 +1,49 @@
 /**
- * Canonical origin, and whether this deployment is the real one.
+ * Canonical origin, and whether this deployment should be indexed.
  *
- * Vercel sets VERCEL_ENV to production | preview | development, and gives every
- * deployment its own *.vercel.app hostname. Both matter for SEO:
+ * Both matter for SEO, in opposite directions:
  *
  *  - Absolute URLs in the sitemap must point at the canonical domain, not at
  *    whatever ephemeral hostname built them.
- *  - Preview deployments must not be indexed at all. A crawlable preview is the
- *    same content on a second domain, which is duplicate content competing with
- *    the real site.
+ *  - Preview deployments must not be indexed. A crawlable preview is the same
+ *    content on a second domain, competing with the real site.
  */
 
 const FALLBACK_SITE_URL = 'https://www.orbs.com'
-
-/** True only on a Vercel production deployment. */
-export const isProductionDeployment = process.env.VERCEL_ENV === 'production'
 
 /**
  * Origin without a trailing slash. Paths from `lib/routes` supply their own
  * leading slash, and carry a trailing one to match `trailingSlash: true`.
  */
 export const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || FALLBACK_SITE_URL).replace(/\/+$/, '')
+
+/** Hostname only — the robots.txt `Host` directive takes no scheme or path. */
+export const siteHost = new URL(siteUrl).host
+
+/**
+ * Should crawlers index this deployment?
+ *
+ * Deliberately not "VERCEL_ENV === 'production'" alone. That reads correctly on
+ * Vercel but makes any deployment without the variable — `next start` behind a
+ * proxy, a container, a different host — permanently `Disallow: /`. That
+ * failure is silent and severe: the site is simply never indexed, and nobody
+ * notices until traffic doesn't arrive.
+ *
+ * So: block what we can positively identify as non-production, allow the rest,
+ * and provide an explicit override for cases neither rule fits.
+ */
+export const shouldAllowIndexing = (() => {
+  const override = process.env.NEXT_PUBLIC_ALLOW_INDEXING
+  if (override === 'true') return true
+  if (override === 'false') return false
+
+  const vercelEnv = process.env.VERCEL_ENV
+  if (vercelEnv) return vercelEnv === 'production'
+
+  // Not on Vercel. Trust NODE_ENV, so a self-hosted production build indexes
+  // and a local dev server does not.
+  return process.env.NODE_ENV === 'production'
+})()
 
 export function absoluteUrl(path: string): string {
   return `${siteUrl}${path.startsWith('/') ? path : `/${path}`}`

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,7 +1,10 @@
 import type { MetadataRoute } from 'next'
 import { absoluteUrl, shouldAllowIndexing, siteHost } from './lib/site'
 
-export const revalidate = 3600
+// Computed per request, not baked at build. robots.txt is a few hundred bytes,
+// and it must reflect the environment actually serving it — a build promoted
+// from preview to production would otherwise keep serving `Disallow: /`.
+export const dynamic = 'force-dynamic'
 
 /**
  * Preview deployments are blocked from indexing entirely.
@@ -12,7 +15,7 @@ export const revalidate = 3600
  * own article is a genuinely bad outcome that is slow to undo.
  */
 export default function robots(): MetadataRoute.Robots {
-  if (!shouldAllowIndexing) {
+  if (!shouldAllowIndexing()) {
     return {
       rules: [{ userAgent: '*', disallow: '/' }],
     }

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from 'next'
+import { absoluteUrl, isProductionDeployment } from './lib/site'
+
+export const revalidate = 3600
+
+/**
+ * Preview deployments are blocked from indexing entirely.
+ *
+ * Every Vercel preview gets its own *.vercel.app hostname serving identical
+ * content. Left crawlable, that is duplicate content on a second domain
+ * competing with the real site — and a preview URL outranking orbs.com for its
+ * own article is a genuinely bad outcome that is slow to undo.
+ */
+export default function robots(): MetadataRoute.Robots {
+  if (!isProductionDeployment) {
+    return {
+      rules: [{ userAgent: '*', disallow: '/' }],
+    }
+  }
+
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        // Route handlers, not content. /api/preview in particular takes a
+        // secret and sets a draft cookie; there is nothing there to index.
+        disallow: '/api/',
+      },
+    ],
+    sitemap: absoluteUrl('/sitemap.xml'),
+    host: absoluteUrl('/'),
+  }
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from 'next'
-import { absoluteUrl, isProductionDeployment } from './lib/site'
+import { absoluteUrl, shouldAllowIndexing, siteHost } from './lib/site'
 
 export const revalidate = 3600
 
@@ -12,7 +12,7 @@ export const revalidate = 3600
  * own article is a genuinely bad outcome that is slow to undo.
  */
 export default function robots(): MetadataRoute.Robots {
-  if (!isProductionDeployment) {
+  if (!shouldAllowIndexing) {
     return {
       rules: [{ userAgent: '*', disallow: '/' }],
     }
@@ -29,6 +29,8 @@ export default function robots(): MetadataRoute.Robots {
       },
     ],
     sitemap: absoluteUrl('/sitemap.xml'),
-    host: absoluteUrl('/'),
+    // Hostname only — a scheme or trailing path makes the directive invalid
+    // and crawlers that honour Host will ignore it.
+    host: siteHost,
   }
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,56 @@
+import type { MetadataRoute } from 'next'
+import { getAllPostRefs, POSTS_PER_PAGE } from './lib/api'
+import { HOME_PATH, blogPagePath, postPath } from './lib/routes'
+import { absoluteUrl } from './lib/site'
+
+// Matches the content routes. Publishing also triggers on-demand revalidation
+// through the Contentful webhook, which sweeps the layout and takes this with it.
+export const revalidate = 3600
+
+/**
+ * Covers what exists today: the home page, the paginated blog index, and every
+ * published post.
+ *
+ * Not yet included, because the routes do not exist:
+ *  - marketing pages (Phase 3)
+ *  - media mentions (#25)
+ *  - hreflang alternates for JP/KO (Phase 2)
+ *
+ * All paths come from `lib/routes` so they carry the trailing slash that
+ * `trailingSlash: true` makes canonical. Emitting the slashless form here would
+ * hand crawlers a URL that 308s on every request.
+ */
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const posts = await getAllPostRefs()
+
+  const newestPostDate = posts.length > 0 ? new Date(posts[0].date) : new Date()
+  const totalPages = Math.max(1, Math.ceil(posts.length / POSTS_PER_PAGE))
+
+  const home: MetadataRoute.Sitemap = [
+    {
+      url: absoluteUrl(HOME_PATH),
+      lastModified: newestPostDate,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+  ]
+
+  // Page 1 is /blog/, not /blog/page/1/ — blogPagePath enforces that, so there
+  // is exactly one URL per page of results and no self-duplicate.
+  const blogPages: MetadataRoute.Sitemap = Array.from({ length: totalPages }, (_, index) => ({
+    url: absoluteUrl(blogPagePath(index + 1)),
+    lastModified: newestPostDate,
+    changeFrequency: 'weekly' as const,
+    // Later pages are older content and matter less than the first.
+    priority: index === 0 ? 0.8 : 0.4,
+  }))
+
+  const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
+    url: absoluteUrl(postPath(post.slug)),
+    lastModified: new Date(post.date),
+    changeFrequency: 'yearly',
+    priority: 0.6,
+  }))
+
+  return [...home, ...blogPages, ...postEntries]
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -3,9 +3,20 @@ import { getAllPostRefs, POSTS_PER_PAGE } from './lib/api'
 import { HOME_PATH, blogPagePath, postPath } from './lib/routes'
 import { absoluteUrl } from './lib/site'
 
-// Matches the content routes. Publishing also triggers on-demand revalidation
-// through the Contentful webhook, which sweeps the layout and takes this with it.
-export const revalidate = 3600
+/**
+ * Computed per request, matching robots.ts.
+ *
+ * Under ISR this was prerendered, so absoluteUrl() ran at build time and the
+ * origin was frozen in — a build served with a different SITE_URL kept emitting
+ * the build-time host in every <loc> while robots.txt correctly switched. Two
+ * SEO files disagreeing about the canonical domain is worse than either being
+ * stale.
+ *
+ * The cost is one Contentful query per request. A sitemap is fetched by
+ * crawlers a handful of times a day, so that is not a hot path — and it is one
+ * `select`-narrowed query returning slug and date, not the full archive.
+ */
+export const dynamic = 'force-dynamic'
 
 /**
  * Covers what exists today: the home page, the paginated blog index, and every

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -34,13 +34,16 @@ export const dynamic = 'force-dynamic'
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const posts = await getAllPostRefs()
 
-  const newestPostDate = posts.length > 0 ? new Date(posts[0].date) : new Date()
+  // Newest MODIFICATION across the archive, not newest publish date — the
+  // listing pages change whenever any post on them changes.
+  const lastArchiveChange =
+    posts.length > 0 ? new Date(Math.max(...posts.map((p) => new Date(p.updatedAt).getTime()))) : new Date()
   const totalPages = Math.max(1, Math.ceil(posts.length / POSTS_PER_PAGE))
 
   const home: MetadataRoute.Sitemap = [
     {
       url: absoluteUrl(HOME_PATH),
-      lastModified: newestPostDate,
+      lastModified: lastArchiveChange,
       changeFrequency: 'weekly',
       priority: 1,
     },
@@ -50,7 +53,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // is exactly one URL per page of results and no self-duplicate.
   const blogPages: MetadataRoute.Sitemap = Array.from({ length: totalPages }, (_, index) => ({
     url: absoluteUrl(blogPagePath(index + 1)),
-    lastModified: newestPostDate,
+    lastModified: lastArchiveChange,
     changeFrequency: 'weekly' as const,
     // Later pages are older content and matter less than the first.
     priority: index === 0 ? 0.8 : 0.4,
@@ -58,7 +61,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
     url: absoluteUrl(postPath(post.slug)),
-    lastModified: new Date(post.date),
+    lastModified: new Date(post.updatedAt),
     changeFrequency: 'yearly',
     priority: 0.6,
   }))


### PR DESCRIPTION
Closes #17.

## What

- `src/app/sitemap.ts` — home, the paginated blog index, and every published post. **498 URLs** today.
- `src/app/robots.ts`
- `src/app/lib/site.ts` — canonical origin and the indexing decision
- `getAllPostSlugs` → `getAllPostRefs`, returning `{ slug, date, updatedAt }` via `select`. The sitemap needs timestamps, and pulling ~460 full Rich Text documents to build a list of URLs is a build cost that grows with the archive.
- Post pages gained a canonical; they had none.

## Preview deployments are blocked from indexing

Every Vercel preview serves identical content on its own `*.vercel.app` hostname. Left crawlable that's duplicate content competing with the real site, and a preview URL outranking orbs.com for its own article is slow to undo.

The check deliberately isn't `VERCEL_ENV === 'production'` alone — that reads correctly on Vercel but makes any deployment without the variable permanently `Disallow: /`. That failure is silent and severe. It now blocks what it can positively identify as non-production, allows the rest, and takes an explicit `ALLOW_INDEXING` override.

## Codex found four things

| Finding | Why it mattered |
| --- | --- |
| Non-Vercel deploys would be `noindex` forever | Silent, severe, no signal until traffic doesn't arrive |
| `Host: https://www.orbs.com/` malformed | Directive takes a hostname; crawlers honouring it would ignore the value |
| Env baked at build time | A promoted build kept serving the previous environment's `Host`/`Sitemap`/rules |
| Sitemap not revalidated on publish | New posts missing from it for up to an hour |
| `<lastmod>` used the publish date | An edited article looked unchanged since publication |
| Relative canonicals | Resolve against the request host, so an alias could self-canonicalize |

The build-time one had a cleaner fix than making everything dynamic: **drop the `NEXT_PUBLIC_` prefix.** That prefix is precisely what makes Next inline a value at build time, and these routes are server-only — so it was wrong to begin with. `SITE_URL` and `ALLOW_INDEXING` are now plain server env vars read at runtime.

Codex verified the sitemap variant itself by starting a build with a different `SITE_URL` and observing robots change while the sitemap didn't. Fixed by making the sitemap `force-dynamic` too — one Contentful query per request, and a sitemap is fetched a handful of times a day.

## Known limitation, deliberately not chased

Content pages are SSG-prerendered, so their canonical is baked from the build-time `SITE_URL`. Making 458 pages `force-dynamic` to track a runtime change isn't a trade worth making: each Vercel environment builds with its own env, and previews are `noindex`, so a preview's canonicals never reach a crawler. `robots.txt` and `sitemap.xml` are dynamic because they're one file each.

## Testing notes

Each branch verified from its own build, and the runtime-vs-build distinction verified from a **single** build:

```
VERCEL_ENV=production      -> Allow: /  Disallow: /api/  Host: www.orbs.com  + Sitemap
VERCEL_ENV=preview         -> Disallow: /
unset, NODE_ENV=production -> Allow: /  (self-hosted case)

one build, SITE_URL=https://staging.example.com:
  robots  Host: staging.example.com
  sitemap <loc>https://staging.example.com/</loc>

sitemap: 498 <url> = 1 home + 39 blog pages + 458 posts
         URLs missing a trailing slash: 0
         https://www.orbs.com/SpookySwap-Integrates-dSLTP/   (mixed case preserved)
canonicals absolute on /blog/, /blog/page/2/ and post pages
```

`tsc --noEmit` clean, `lint` clean.

## Not covered yet

Marketing pages (Phase 3), media mentions (#25), and hreflang alternates (Phase 2) — none of those routes exist. The issue notes the sitemap should be revisited after each.