### PR TITLE
chore: stop Dependabot raising non-security major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,19 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # Majors are migrations, not upgrades — Tailwind 3->4 is a new config
+    # format and engine, TypeScript 7 and ESLint 10 both carry breaking
+    # changes. Dependabot opened five of them within minutes of this config
+    # landing, none backed by an advisory. They belong in a deliberate piece of
+    # work with the test suite to check against, not in a bot's queue where
+    # they sit looking actionable and train everyone to ignore the list.
+    #
+    # Security updates are unaffected: Dependabot raises those regardless of
+    # this filter, including majors.
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
     groups:
       # Test and story tooling never reaches the runtime bundle, so these can
       # land together without per-package scrutiny.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,19 +8,40 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
-    # Majors are migrations, not upgrades — Tailwind 3->4 is a new config
-    # format and engine, TypeScript 7 and ESLint 10 both carry breaking
-    # changes. Dependabot opened five of them within minutes of this config
-    # landing, none backed by an advisory. They belong in a deliberate piece of
-    # work with the test suite to check against, not in a bot's queue where
-    # they sit looking actionable and train everyone to ignore the list.
+    # Majors of the TEST AND STORY TOOLING only.
     #
-    # Security updates are unaffected: Dependabot raises those regardless of
-    # this filter, including majors.
+    # Dependabot opened five major PRs within minutes of this config landing —
+    # tailwindcss 3->4, typescript 5->7, eslint 9->10, vite 7->8,
+    # cf-content-types-generator 2->3 — none backed by an advisory. Those are
+    # migrations, not upgrades: Tailwind 4 is a new config format and engine.
+    # They belong in deliberate work with the test suite to check against, not
+    # sitting open looking actionable, which is how a list stops being read.
+    #
+    # Scoped by name rather than `dependency-name: '*'` ON PURPOSE. GitHub
+    # applies `ignore` to security updates as well as version updates, so a
+    # wildcard would suppress the only automated fix for any advisory that is
+    # remediated in a major — precisely the case where you most want the PR.
+    # Naming the packages keeps next, react, contentful and everything else
+    # that ships on the default path.
     ignore:
-      - dependency-name: '*'
-        update-types:
-          - version-update:semver-major
+      - dependency-name: 'tailwindcss'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'vite'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'cf-content-types-generator'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'storybook'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@storybook/*'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'vitest'
+        update-types: ['version-update:semver-major']
+      - dependency-name: '@vitest/*'
+        update-types: ['version-update:semver-major']
     groups:
       # Test and story tooling never reaches the runtime bundle, so these can
       # land together without per-package scrutiny.


### PR DESCRIPTION
Dependabot opened **five major-version PRs within minutes** of the config from #57 landing:

- #62 tailwindcss 3.4.19 → 4.3.3
- #61 typescript 5.9.3 → 7.0.2
- #60 eslint 9.39.5 → 10.8.1
- #59 cf-content-types-generator 2.16.1 → 3.0.1
- #58 vite 7.3.6 → 8.2.1

I checked each against the repo's open alerts — **none has a security advisory behind it**. All five are closed.

## Why filter them

Majors here are migrations, not upgrades. Tailwind 4 is a new config format and engine; TypeScript 7 and ESLint 10 both carry breaking changes. Those belong in deliberate work with the test suite to check against.

The real cost of leaving them is that a list of five stale, unactionable PRs trains everyone to stop reading the list — which is precisely how a genuine advisory gets missed.

**Security updates are unaffected.** Dependabot raises those regardless of an `ignore` filter, majors included.

## Testing notes

Config-only. YAML validated.