### PR TITLE
feat: model the mediaMention content type

### DIFF
--- a/scripts/orbs-website-migration/scripts/create-media-mention-type.mjs
+++ b/scripts/orbs-website-migration/scripts/create-media-mention-type.mjs
@@ -1,0 +1,129 @@
+// scripts/create-media-mention-type.mjs
+//
+// Creates (or updates) the `mediaMention` content type.
+//
+// /news on the legacy site is 333 press-coverage cards — headline, thumbnail,
+// publisher logo, external URL, date. No body, no page of its own: every card
+// links out. New entries land roughly weekly, added by comms, which is why this
+// lives in Contentful rather than being hardcoded like the marketing pages.
+// See docs/migration-plan.md section 2.2.
+//
+// Usage:
+//   node scripts/create-media-mention-type.mjs          # dry run
+//   node scripts/create-media-mention-type.mjs --apply
+//
+// Requires CONTENTFUL_MANAGEMENT_TOKEN and CONTENTFUL_SPACE_ID.
+
+import 'dotenv/config'
+import contentful from 'contentful-management'
+
+const {
+  CONTENTFUL_MANAGEMENT_TOKEN,
+  CONTENTFUL_SPACE_ID,
+  CONTENTFUL_ENVIRONMENT_ID = 'master',
+} = process.env
+
+const APPLY = process.argv.includes('--apply')
+
+if (!CONTENTFUL_MANAGEMENT_TOKEN || !CONTENTFUL_SPACE_ID) {
+  throw new Error('Missing CONTENTFUL_MANAGEMENT_TOKEN or CONTENTFUL_SPACE_ID')
+}
+
+const CONTENT_TYPE_ID = 'mediaMention'
+
+const definition = {
+  name: 'Media Mention',
+  description:
+    'External press coverage of Orbs. Displayed as a card on /news that links out to the publisher; it has no page of its own.',
+  displayField: 'headline',
+  fields: [
+    {
+      id: 'headline',
+      name: 'Headline',
+      // Text, not Symbol. Symbol caps at 256 and 12 of the 333 legacy
+      // headlines exceed that, the longest at 370. blogPost.shortDescription
+      // is a Symbol and that is exactly why 106 of its values arrived
+      // machine-truncated — not repeating it here.
+      type: 'Text',
+      required: true,
+      localized: false,
+      validations: [{ size: { max: 500 } }],
+    },
+    {
+      id: 'url',
+      name: 'Article URL',
+      type: 'Symbol',
+      required: true,
+      localized: false,
+      // Unique: the same article should not be entered twice. This is the only
+      // natural key a media mention has — there is no slug.
+      validations: [{ unique: true }, { regexp: { pattern: '^https?://' } }],
+    },
+    {
+      id: 'date',
+      name: 'Published date',
+      type: 'Date',
+      required: true,
+      localized: false,
+    },
+    {
+      id: 'thumbnail',
+      name: 'Thumbnail',
+      type: 'Link',
+      linkType: 'Asset',
+      required: false,
+      localized: false,
+      validations: [{ linkMimetypeGroup: ['image'] }],
+    },
+    {
+      id: 'publisherLogo',
+      name: 'Publisher logo',
+      // Deliberately an asset link rather than a `publisher` reference type.
+      // 70 distinct logos serve 333 entries, so reuse is real — but the legacy
+      // data has only logo FILENAMES, no publisher names. A publisher entity
+      // would mean inventing the names, and a shared asset link already gives
+      // the dedup. Revisit if editors ever need publisher metadata.
+      type: 'Link',
+      linkType: 'Asset',
+      required: false,
+      localized: false,
+      validations: [{ linkMimetypeGroup: ['image'] }],
+    },
+  ],
+}
+
+async function main() {
+  const client = contentful.createClient({ accessToken: CONTENTFUL_MANAGEMENT_TOKEN })
+  const space = await client.getSpace(CONTENTFUL_SPACE_ID)
+  const env = await space.getEnvironment(CONTENTFUL_ENVIRONMENT_ID)
+
+  let existing = null
+  try {
+    existing = await env.getContentType(CONTENT_TYPE_ID)
+  } catch {
+    // not created yet
+  }
+
+  console.log(`\ncontent type : ${CONTENT_TYPE_ID}`)
+  console.log(`state        : ${existing ? 'exists — will update' : 'does not exist — will create'}`)
+  console.log(`fields       : ${definition.fields.map((f) => `${f.id}:${f.type}${f.required ? '*' : ''}`).join(', ')}`)
+
+  if (!APPLY) {
+    console.log('\nDry run. Nothing written. Re-run with --apply.\n')
+    return
+  }
+
+  const contentType = existing
+    ? Object.assign(existing, definition)
+    : await env.createContentTypeWithId(CONTENT_TYPE_ID, definition)
+
+  const saved = existing ? await contentType.update() : contentType
+  await saved.publish()
+
+  console.log(`\n${existing ? 'Updated' : 'Created'} and published: ${CONTENT_TYPE_ID}\n`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/app/generated-types/TypeMediaMention.ts
+++ b/src/app/generated-types/TypeMediaMention.ts
@@ -1,0 +1,12 @@
+import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
+
+export interface TypeMediaMentionFields {
+    headline: EntryFieldTypes.Text;
+    url: EntryFieldTypes.Symbol;
+    date: EntryFieldTypes.Date;
+    thumbnail?: EntryFieldTypes.AssetLink;
+    publisherLogo?: EntryFieldTypes.AssetLink;
+}
+
+export type TypeMediaMentionSkeleton = EntrySkeletonType<TypeMediaMentionFields, "mediaMention">;
+export type TypeMediaMention<Modifiers extends ChainModifiers, Locales extends LocaleCode = LocaleCode> = Entry<TypeMediaMentionSkeleton, Modifiers, Locales>;

--- a/src/app/generated-types/index.ts
+++ b/src/app/generated-types/index.ts
@@ -1,2 +1,3 @@
 export type { TypeAuthor, TypeAuthorFields, TypeAuthorSkeleton } from "./TypeAuthor";
 export type { TypeBlogPost, TypeBlogPostFields, TypeBlogPostSkeleton } from "./TypeBlogPost";
+export type { TypeMediaMention, TypeMediaMentionFields, TypeMediaMentionSkeleton } from "./TypeMediaMention";

--- a/src/contentful-types/contentful-export-ivp9qsr6kthp-master.json
+++ b/src/contentful-types/contentful-export-ivp9qsr6kthp-master.json
@@ -9,6 +9,76 @@
             "id": "ivp9qsr6kthp"
           }
         },
+        "id": "author",
+        "type": "ContentType",
+        "createdAt": "2024-08-13T12:55:47.151Z",
+        "updatedAt": "2025-12-17T13:46:00.503Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 3,
+        "publishedAt": "2025-12-17T13:46:00.503Z",
+        "firstPublishedAt": "2024-08-13T12:55:47.485Z",
+        "publishedCounter": 2,
+        "version": 4
+      },
+      "displayField": "name",
+      "name": "Author",
+      "description": "",
+      "fields": [
+        {
+          "id": "name",
+          "name": "Name",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "profilePicture",
+          "name": "Profile Picture",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "profileUrl",
+          "name": "Profile Url",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "regexp": {
+                "pattern": "^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-/]))?$",
+                "flags": null
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "ivp9qsr6kthp"
+          }
+        },
         "id": "blogPost",
         "type": "ContentType",
         "createdAt": "2024-08-13T10:32:07.824Z",
@@ -23,30 +93,8 @@
         "publishedVersion": 23,
         "publishedAt": "2025-12-17T17:16:52.964Z",
         "firstPublishedAt": "2024-08-13T10:32:08.110Z",
-        "createdBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "5bHXDVvLe9RLNIAgj4XV9v"
-          }
-        },
-        "updatedBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "5bHXDVvLe9RLNIAgj4XV9v"
-          }
-        },
         "publishedCounter": 12,
-        "version": 24,
-        "publishedBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "5bHXDVvLe9RLNIAgj4XV9v"
-          }
-        },
-        "urn": "crn:contentful:::content:spaces/ivp9qsr6kthp/environments/master/content_types/blogPost"
+        "version": 24
       },
       "displayField": "title",
       "name": "Blog Post",
@@ -72,8 +120,7 @@
           "type": "Link",
           "localized": true,
           "required": false,
-          "validations": [
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false,
           "linkType": "Asset"
@@ -120,8 +167,7 @@
               "message": "Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to asset, inline entry, link to entry, and link to Url nodes are allowed"
             },
             {
-              "nodes": {
-              }
+              "nodes": {}
             }
           ],
           "disabled": false,
@@ -133,8 +179,7 @@
           "type": "Date",
           "localized": false,
           "required": true,
-          "validations": [
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -144,8 +189,7 @@
           "type": "Symbol",
           "localized": true,
           "required": false,
-          "validations": [
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -155,8 +199,7 @@
           "type": "Symbol",
           "localized": true,
           "required": false,
-          "validations": [
-          ],
+          "validations": [],
           "disabled": false,
           "omitted": false
         },
@@ -188,10 +231,10 @@
             "id": "ivp9qsr6kthp"
           }
         },
-        "id": "author",
+        "id": "mediaMention",
         "type": "ContentType",
-        "createdAt": "2024-08-13T12:55:47.151Z",
-        "updatedAt": "2025-12-17T13:46:00.503Z",
+        "createdAt": "2026-08-13T15:38:08.368Z",
+        "updatedAt": "2026-08-13T15:38:08.819Z",
         "environment": {
           "sys": {
             "id": "master",
@@ -199,127 +242,142 @@
             "linkType": "Environment"
           }
         },
-        "publishedVersion": 3,
-        "publishedAt": "2025-12-17T13:46:00.503Z",
-        "firstPublishedAt": "2024-08-13T12:55:47.485Z",
-        "createdBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "5bHXDVvLe9RLNIAgj4XV9v"
-          }
-        },
-        "updatedBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "5bHXDVvLe9RLNIAgj4XV9v"
-          }
-        },
-        "publishedCounter": 2,
-        "version": 4,
-        "publishedBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "5bHXDVvLe9RLNIAgj4XV9v"
-          }
-        },
-        "urn": "crn:contentful:::content:spaces/ivp9qsr6kthp/environments/master/content_types/author"
+        "publishedVersion": 1,
+        "publishedAt": "2026-08-13T15:38:08.819Z",
+        "firstPublishedAt": "2026-08-13T15:38:08.819Z",
+        "publishedCounter": 1,
+        "version": 2
       },
-      "displayField": "name",
-      "name": "Author",
-      "description": "",
+      "displayField": "headline",
+      "name": "Media Mention",
+      "description": "External press coverage of Orbs. Displayed as a card on /news that links out to the publisher; it has no page of its own.",
       "fields": [
         {
-          "id": "name",
-          "name": "Name",
-          "type": "Symbol",
+          "id": "headline",
+          "name": "Headline",
+          "type": "Text",
           "localized": false,
           "required": true,
           "validations": [
+            {
+              "size": {
+                "max": 500
+              }
+            }
           ],
           "disabled": false,
           "omitted": false
         },
         {
-          "id": "profilePicture",
-          "name": "Profile Picture",
+          "id": "url",
+          "name": "Article URL",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "unique": true
+            },
+            {
+              "regexp": {
+                "pattern": "^https?://"
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "date",
+          "name": "Published date",
+          "type": "Date",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "thumbnail",
+          "name": "Thumbnail",
           "type": "Link",
           "localized": false,
           "required": false,
           "validations": [
+            {
+              "linkMimetypeGroup": [
+                "image"
+              ]
+            }
           ],
           "disabled": false,
           "omitted": false,
           "linkType": "Asset"
         },
         {
-          "id": "profileUrl",
-          "name": "Profile Url",
-          "type": "Symbol",
+          "id": "publisherLogo",
+          "name": "Publisher logo",
+          "type": "Link",
           "localized": false,
           "required": false,
           "validations": [
             {
-              "regexp": {
-                "pattern": "^(ftp|http|https):\\/\\/(\\w+:{0,1}\\w*@)?(\\S+)(:[0-9]+)?(\\/|\\/([\\w#!:.?+=&%@!\\-/]))?$",
-                "flags": null
-              }
+              "linkMimetypeGroup": [
+                "image"
+              ]
             }
           ],
           "disabled": false,
-          "omitted": false
+          "omitted": false,
+          "linkType": "Asset"
         }
       ]
     }
   ],
-  "tags": [
-  ],
+  "tags": [],
   "locales": [
     {
-      "name": "English (United States)",
       "code": "en-US",
-      "fallbackCode": null,
+      "name": "English (United States)",
       "default": true,
+      "optional": false,
+      "fallbackCode": null,
       "contentManagementApi": true,
       "contentDeliveryApi": true,
-      "optional": false,
       "sys": {
-        "type": "Locale",
         "id": "7qY6ePr2I4L1vq1UdHZ1Mj",
+        "type": "Locale",
         "version": 1,
         "space": {
           "sys": {
             "type": "Link",
-            "linkType": "Space",
-            "id": "ivp9qsr6kthp"
+            "id": "ivp9qsr6kthp",
+            "linkType": "Space"
           }
         },
         "environment": {
           "sys": {
             "type": "Link",
             "linkType": "Environment",
-            "id": "master",
-            "uuid": "f6ed5213-36a0-401b-8c63-d545b5047dcf"
-          }
-        },
-        "createdBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "5bHXDVvLe9RLNIAgj4XV9v"
+            "id": "master"
           }
         },
         "createdAt": "2024-08-13T10:30:15Z",
+        "updatedAt": "2024-08-13T10:30:15Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "id": "5bHXDVvLe9RLNIAgj4XV9v",
+            "linkType": "User"
+          }
+        },
         "updatedBy": {
           "sys": {
             "type": "Link",
-            "linkType": "User",
-            "id": "5bHXDVvLe9RLNIAgj4XV9v"
+            "id": "5bHXDVvLe9RLNIAgj4XV9v",
+            "linkType": "User"
           }
-        },
-        "updatedAt": "2024-08-13T10:30:15Z"
+        }
       }
     }
   ]


### PR DESCRIPTION
Closes #23. First piece of Phase 1b.

`/news` on the legacy site is **333 press-coverage cards** — headline, thumbnail, publisher logo, external URL, date. No body, no page of its own: every card links out. New entries land roughly weekly, added by comms, which is why this belongs in Contentful rather than being hardcoded like the marketing pages (migration plan 2.2).

## Two decisions taken from the data, not by default

**`headline` is `Text`, not `Symbol`.** Symbol caps at 256 and **12 of the 333 legacy headlines exceed it**, the longest at 370. `blogPost.shortDescription` is a Symbol, and that's exactly why 106 of its values arrived machine-truncated. Not repeating that.

**No separate `publisher` type.** 70 distinct logos serve 333 entries, so the reuse is real — but the legacy data has only logo *filenames*, no publisher names. An entity would mean inventing them. A shared asset link gives the dedup without the invention; documented in the script for whenever editors actually need publisher metadata.

`url` is unique — it's the only natural key a media mention has, since there's no slug, and it stops the same article being entered twice.

## Content model export

Replaces the December 2025 export with a fresh one pulled from the space, and regenerates the types.

`npm run export-content` needs `contentful-cli-config.json`, which is gitignored and absent, so the export is fetched through the management API instead. Same shape as the CLI produces.

## Applied

Content type created and published in the space. Verified through the delivery API:

```
mediaMention     headline, url, date, thumbnail, publisherLogo
blogPost         title, heroImage, content, date, shortDescription, slug, author
author           name, profilePicture, profileUrl
```

`tsc --noEmit` clean, `lint` clean.

## Next

#24 migrates the 333 entries and their thumbnails/logos; #25 builds the `/news` listing page.