### PR TITLE
fix: link /news from the main navigation

### DIFF
--- a/src/app/components/layout/navigation/nav-menu.tsx
+++ b/src/app/components/layout/navigation/nav-menu.tsx
@@ -88,6 +88,10 @@ export function NavMenu() {
         <li>
           <NavButton href="/blog">Blog</NavButton>
         </li>
+        <li>
+          {/* "Media" matches the legacy navbar and footer label for /news. */}
+          <NavButton href="/news">Media</NavButton>
+        </li>
       </ul>
     </div>
   )


### PR DESCRIPTION
## What

Adds a **Media** link to the main navigation, pointing at `/news`.

## Why

Phase 1b shipped the `/news` listing (#68) but nothing linked to it — the page
was live and unreachable except by typing the URL.

"Media" is the label, not "News": that matches the legacy navbar and footer,
so the nav reads the same as the site users are being migrated from.

## Testing

Built and checked the rendered nav on `/blog/` — `>Media<` appears exactly once.
(Checked on a page with no news pagination, so the match cannot be a pagination
link — the mistake that made the first attempt at this verification worthless.)