### PR TITLE
chore(deps): bump lucide-react from 0.562.0 to 1.31.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "contentful": "^10.13.3",
-        "lucide-react": "^0.562.0",
+        "lucide-react": "^1.31.0",
         "next": "^16.3.1",
         "next-intl": "^4.13.7",
         "next-themes": "^0.4.6",
@@ -11197,9 +11197,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.562.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
-      "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.31.0.tgz",
+      "integrity": "sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "contentful": "^10.13.3",
-    "lucide-react": "^0.562.0",
+    "lucide-react": "^1.31.0",
     "next": "^16.3.1",
     "next-intl": "^4.13.7",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
Replaces #65.

A 0.x → 1.x major on a dependency that renders to the screen, so green CI is not
sufficient evidence: it proves the icons still *resolve*, not that they still
*look the same*. Lucide's 1.0 release redrew part of the icon set.

## Verification

Diffed the shipped SVG path geometry between `lucide-react@0.562.0` and
`@1.31.0` for every icon this project uses:

```
arrow-down     identical geometry
arrow-left     identical geometry
arrow-right    identical geometry
arrow-up       identical geometry
check          identical geometry
chevron-down   identical geometry
chevron-right  identical geometry
circle         identical geometry
computer       identical geometry
download       identical geometry
moon           identical geometry
sun            identical geometry
```

Nothing renders differently. Also confirmed all 14 imported names — including
the `ArrowLeftIcon` / `ChevronDownIcon` aliases — still export, since 1.0 renamed
some icons.

## Note for later

The package layout changed: icons moved from `dist/esm/icons/*.js` to `*.mjs`.
No deep imports here, so it doesn't affect us — but a future deep import would
break against this version.

## Testing

Build clean (531 pages), typecheck clean, lint clean, 61 tests passing.