### PR TITLE
chore(deps): bump contentful from 10.15.1 to 11.12.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "contentful": "^10.13.3",
+        "contentful": "^11.12.9",
         "lucide-react": "^1.31.0",
         "next": "^16.3.1",
         "next-intl": "^4.13.7",
@@ -397,12 +397,12 @@
       }
     },
     "node_modules/@contentful/content-source-maps": {
-      "version": "0.11.44",
-      "resolved": "https://registry.npmjs.org/@contentful/content-source-maps/-/content-source-maps-0.11.44.tgz",
-      "integrity": "sha512-tu1gfmZI59hQ7qKhmGOV0dA5brxhsc+LOfPwBsQQMDAVy5kVpTrKf/AGlL2y9QhKHu/NtCrwX/ZrmRFgtGEtIA==",
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/@contentful/content-source-maps/-/content-source-maps-0.12.3.tgz",
+      "integrity": "sha512-HzimXvs48eg+tjWtDuOIZzjbSYxfC8CLMZaTwzPqF6wW0TM5KoQIfDJZrGlnpGrZ66lXvyEc5nuYCa58ow8C7g==",
       "license": "MIT",
       "dependencies": {
-        "@vercel/stega": "^0.1.2",
+        "@vercel/stega": "^1.1.0",
         "json-pointer": "^0.6.2"
       }
     },
@@ -4109,7 +4109,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5698,9 +5697,9 @@
       ]
     },
     "node_modules/@vercel/stega": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@vercel/stega/-/stega-0.1.2.tgz",
-      "integrity": "sha512-P7mafQXjkrsoyTRppnt0N21udKS9wUmLXHRyP9saLXLHw32j/FgUJ3FscSWgvSqRs4cj7wKZtwqJEvWJ2jbGmA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/stega/-/stega-1.1.0.tgz",
+      "integrity": "sha512-DFOm3Gk78nKDkppQEG5aj8Wj8R8hPKu/xrz4Rtp0AfiaNbZNCoJbxn7VI6iMxqhGeLdUDy/8mTuTWMz/izAtPA==",
       "license": "MPL-2.0"
     },
     "node_modules/@vitest/browser": {
@@ -6720,6 +6719,103 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/cf-content-types-generator/node_modules/@contentful/content-source-maps": {
+      "version": "0.11.44",
+      "resolved": "https://registry.npmjs.org/@contentful/content-source-maps/-/content-source-maps-0.11.44.tgz",
+      "integrity": "sha512-tu1gfmZI59hQ7qKhmGOV0dA5brxhsc+LOfPwBsQQMDAVy5kVpTrKf/AGlL2y9QhKHu/NtCrwX/ZrmRFgtGEtIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vercel/stega": "^0.1.2",
+        "json-pointer": "^0.6.2"
+      }
+    },
+    "node_modules/cf-content-types-generator/node_modules/@contentful/rich-text-types": {
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
+      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/cf-content-types-generator/node_modules/@vercel/stega": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@vercel/stega/-/stega-0.1.2.tgz",
+      "integrity": "sha512-P7mafQXjkrsoyTRppnt0N21udKS9wUmLXHRyP9saLXLHw32j/FgUJ3FscSWgvSqRs4cj7wKZtwqJEvWJ2jbGmA==",
+      "dev": true,
+      "license": "MPL-2.0"
+    },
+    "node_modules/cf-content-types-generator/node_modules/contentful": {
+      "version": "10.15.1",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.15.1.tgz",
+      "integrity": "sha512-vPgQvpzqWHauroXrhPOW03iz/ZVqZrv6BX2Fk/vMOlMMB7a+zrhUWAuUjY9WFDVMRcAwPhZF2Lvey6Nvyyd6sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@contentful/content-source-maps": "^0.11.0",
+        "@contentful/rich-text-types": "^16.0.2",
+        "axios": "^1.7.4",
+        "contentful-resolve-response": "^1.9.0",
+        "contentful-sdk-core": "^8.3.1",
+        "json-stringify-safe": "^5.0.1",
+        "type-fest": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cf-content-types-generator/node_modules/contentful-resolve-response": {
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.9.9.tgz",
+      "integrity": "sha512-ApbQGPuMJe/jJOlYzO1cMpIXpE3MG8actgkaJO8lbbh9GrTOIStR35RJ1W8dcpb20KCuueSBcOWFIn2y6LnOog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-copy": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4.7.2"
+      }
+    },
+    "node_modules/cf-content-types-generator/node_modules/contentful-sdk-core": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.3.2.tgz",
+      "integrity": "sha512-L2LNWRXb1/5RLpLemCoP2Lzz6211xyE63GXh2nVXekvM4Dnswo+9N2D6JmWTne9zq89Izo88vOGAzzIAxb4Ukw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-copy": "^2.1.7",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "p-throttle": "^4.1.1",
+        "qs": "^6.11.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cf-content-types-generator/node_modules/contentful-sdk-core/node_modules/fast-copy": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.2.0.tgz",
+      "integrity": "sha512-+T1bBiRiRGn7aKFqD0FEebYEzYgqK/uOlKCy2stsAgqSRI4T7nxmoTd1i8XmaGXp9B47yYXvx+V65yoz3DFAUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cf-content-types-generator/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -7189,17 +7285,18 @@
       "license": "MIT"
     },
     "node_modules/contentful": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.15.1.tgz",
-      "integrity": "sha512-vPgQvpzqWHauroXrhPOW03iz/ZVqZrv6BX2Fk/vMOlMMB7a+zrhUWAuUjY9WFDVMRcAwPhZF2Lvey6Nvyyd6sQ==",
+      "version": "11.12.9",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-11.12.9.tgz",
+      "integrity": "sha512-3eSYeXRiQOOmkwwAqwPXeTE37iiE/Ku4LOh1p5bj2CxgaLVLk6O2Ep1DdDwoGMonyTNrkbCFXfbXCkrTPYBWHw==",
       "license": "MIT",
       "dependencies": {
-        "@contentful/content-source-maps": "^0.11.0",
-        "@contentful/rich-text-types": "^16.0.2",
-        "axios": "^1.7.4",
-        "contentful-resolve-response": "^1.9.0",
-        "contentful-sdk-core": "^8.3.1",
+        "@contentful/content-source-maps": "^0.12.0",
+        "@contentful/rich-text-types": "^17.2.7",
+        "axios": "^1.15.0",
+        "contentful-resolve-response": "^2.0.0",
+        "contentful-sdk-core": "^9.4.4",
         "json-stringify-safe": "^5.0.1",
+        "tslib": "^2.8.1",
         "type-fest": "^4.0.0"
       },
       "engines": {
@@ -7294,89 +7391,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/contentful-export/node_modules/@contentful/content-source-maps": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/@contentful/content-source-maps/-/content-source-maps-0.12.3.tgz",
-      "integrity": "sha512-HzimXvs48eg+tjWtDuOIZzjbSYxfC8CLMZaTwzPqF6wW0TM5KoQIfDJZrGlnpGrZ66lXvyEc5nuYCa58ow8C7g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vercel/stega": "^1.1.0",
-        "json-pointer": "^0.6.2"
-      }
-    },
-    "node_modules/contentful-export/node_modules/@vercel/stega": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@vercel/stega/-/stega-1.1.0.tgz",
-      "integrity": "sha512-DFOm3Gk78nKDkppQEG5aj8Wj8R8hPKu/xrz4Rtp0AfiaNbZNCoJbxn7VI6iMxqhGeLdUDy/8mTuTWMz/izAtPA==",
-      "dev": true,
-      "license": "MPL-2.0"
-    },
-    "node_modules/contentful-export/node_modules/contentful": {
-      "version": "11.12.9",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-11.12.9.tgz",
-      "integrity": "sha512-3eSYeXRiQOOmkwwAqwPXeTE37iiE/Ku4LOh1p5bj2CxgaLVLk6O2Ep1DdDwoGMonyTNrkbCFXfbXCkrTPYBWHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@contentful/content-source-maps": "^0.12.0",
-        "@contentful/rich-text-types": "^17.2.7",
-        "axios": "^1.15.0",
-        "contentful-resolve-response": "^2.0.0",
-        "contentful-sdk-core": "^9.4.4",
-        "json-stringify-safe": "^5.0.1",
-        "tslib": "^2.8.1",
-        "type-fest": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/contentful-export/node_modules/contentful-resolve-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-2.0.1.tgz",
-      "integrity": "sha512-IYjx6oI1G4wSlLecceDBKuXZRezVrNwZSxfmM0ZjwWtCeyR0B0iYPGNgEu3/p1kGJliFziZRFA61jM8wa1Trcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-copy": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/contentful-export/node_modules/contentful-sdk-core": {
-      "version": "9.4.5",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.4.5.tgz",
-      "integrity": "sha512-8eGTMO11LXFAiosaiV38bjvW6cjoQFtNE38pNtVilZTXpmGFinClljihH0eriv11Ispd4q82TqtsXMJPYD/C+A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-copy": "^3.0.2",
-        "lodash": "^4.17.23",
-        "process": "^0.11.10",
-        "qs": "^6.15.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-linux-x64-gnu": "^4.18.0"
-      }
-    },
-    "node_modules/contentful-export/node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/contentful-management": {
       "version": "11.76.0",
       "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-11.76.0.tgz",
@@ -7404,11 +7418,22 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/contentful-management/node_modules/contentful-sdk-core": {
+    "node_modules/contentful-resolve-response": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-2.0.1.tgz",
+      "integrity": "sha512-IYjx6oI1G4wSlLecceDBKuXZRezVrNwZSxfmM0ZjwWtCeyR0B0iYPGNgEu3/p1kGJliFziZRFA61jM8wa1Trcg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-copy": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/contentful-sdk-core": {
       "version": "9.4.5",
       "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-9.4.5.tgz",
       "integrity": "sha512-8eGTMO11LXFAiosaiV38bjvW6cjoQFtNE38pNtVilZTXpmGFinClljihH0eriv11Ispd4q82TqtsXMJPYD/C+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-copy": "^3.0.2",
@@ -7421,49 +7446,6 @@
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.18.0"
-      }
-    },
-    "node_modules/contentful-resolve-response": {
-      "version": "1.9.9",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.9.9.tgz",
-      "integrity": "sha512-ApbQGPuMJe/jJOlYzO1cMpIXpE3MG8actgkaJO8lbbh9GrTOIStR35RJ1W8dcpb20KCuueSBcOWFIn2y6LnOog==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-copy": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=4.7.2"
-      }
-    },
-    "node_modules/contentful-sdk-core": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.3.2.tgz",
-      "integrity": "sha512-L2LNWRXb1/5RLpLemCoP2Lzz6211xyE63GXh2nVXekvM4Dnswo+9N2D6JmWTne9zq89Izo88vOGAzzIAxb4Ukw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-copy": "^2.1.7",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "p-throttle": "^4.1.1",
-        "qs": "^6.11.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/contentful-sdk-core/node_modules/fast-copy": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
-      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA==",
-      "license": "MIT"
-    },
-    "node_modules/contentful/node_modules/@contentful/rich-text-types": {
-      "version": "16.8.5",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-16.8.5.tgz",
-      "integrity": "sha512-q18RJuJCOuYveGiCIjE5xLCQc5lZ3L2Qgxrlg/H2YEobDFqdtmklazRi1XwEWaK3tMg6yVXBzKKkQfLB4qW14A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/contentful/node_modules/type-fest": {
@@ -10926,7 +10908,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -10961,12 +10942,14 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.merge": {
@@ -12053,6 +12036,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-4.1.1.tgz",
       "integrity": "sha512-TuU8Ato+pRTPJoDzYD4s7ocJYcNSEZRvlxoq3hcPI2kZDZ49IQ1Wkj7/gDJc3X7XiEAAvRGtDzdXJI0tC3IL1g==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -12485,7 +12469,6 @@
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
       "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "contentful": "^10.13.3",
+    "contentful": "^11.12.9",
     "lucide-react": "^1.31.0",
     "next": "^16.3.1",
     "next-intl": "^4.13.7",


### PR DESCRIPTION
Replaces #67.

**Tier 3 by risk, not size.** This is the client that all 456 posts, the blog
index, the news listing, the RSS feed, the sitemap and draft mode read through.
The diff is two files — `package.json` and the lockfile — so reading it proves
nothing. Verified against the live space instead.

## v11 drops the default export

```
import contentful from 'contentful'
→ SyntaxError: The requested module 'contentful' does not provide an export named 'default'
```

`src/app/lib/api.ts:1` uses a namespace import (`import * as contentful`), which
still resolves — so nothing here breaks. Found by writing the probe with a
default import first and watching it fail.

Worth recording: any future file reaching for the default import breaks against
v11, and it fails at module load rather than at the call site.

## Behavioural diff, v10 vs v11

Ran identical queries on both versions against live data. Output was
byte-identical:

| Check | Result |
| --- | --- |
| Archive enumeration, select + order | 456 entries, same slugs, same order |
| `select` narrowing | still returns only the 2 requested fields |
| `sys.updatedAt` | still populated |
| Single post by slug | same 7 field keys |
| Author link resolution | still resolved to an object |
| Rich Text | still parsed to a `document` node |
| Media mentions | 326 entries, same 5 field keys |

## Draft mode

Checked separately, because the build never exercises it. The preview client
against `preview.contentful.com` returns 458 entries — the 456 published plus 2
drafts — with links resolved.

## Testing

Build clean (531 pages), typecheck clean, lint clean, 61 tests passing.