### PR TITLE
feat: port the site footer from the legacy site

### DIFF
--- a/src/app/components/layout/footer/footer-nav.stories.tsx
+++ b/src/app/components/layout/footer/footer-nav.stories.tsx
@@ -1,0 +1,208 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { expect, within } from 'storybook/test'
+import type { FooterLinkSpec } from '@/content/shared/footer'
+import { FooterNavColumn } from './footer-nav'
+
+const meta = {
+  title: 'Layout/FooterNavColumn',
+  component: FooterNavColumn,
+} satisfies Meta<typeof FooterNavColumn>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const spec = (key: string, href: string, localeHref?: FooterLinkSpec['localeHref']): FooterLinkSpec => ({
+  key,
+  href,
+  ...(localeHref ? { localeHref } : {}),
+})
+
+/**
+ * Internal paths pick up the trailing slash `trailingSlash: true` requires, and
+ * stay in-document. External ones open in a new tab with a safe `rel`.
+ */
+export const InternalAndExternalLinks: Story = {
+  args: {
+    id: 'footer-resources',
+    title: 'Resources',
+    locale: 'en',
+    items: [
+      { spec: spec('faq', '/faq'), label: 'FAQ' },
+      { spec: spec('developers', 'https://docs.orbs.network/'), label: 'Developers' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const internal = canvas.getByRole('link', { name: 'FAQ' })
+    const external = canvas.getByRole('link', { name: 'Developers' })
+
+    await expect(internal).toHaveAttribute('href', '/faq/')
+    await expect(internal).not.toHaveAttribute('target')
+
+    await expect(external).toHaveAttribute('href', 'https://docs.orbs.network/')
+    await expect(external).toHaveAttribute('target', '_blank')
+    await expect(external).toHaveAttribute('rel', 'noopener noreferrer')
+  },
+}
+
+/**
+ * The column heading names the `<nav>`, so assistive tech can tell four sibling
+ * navigation landmarks apart instead of announcing "navigation" four times.
+ */
+export const HeadingLabelsTheLandmark: Story = {
+  args: {
+    id: 'footer-community',
+    title: 'Community',
+    locale: 'en',
+    items: [{ spec: spec('contact', '/contact'), label: 'Contact' }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('navigation', { name: 'Community' })).toBeInTheDocument()
+  },
+}
+
+/**
+ * A locale whose page is a real translation gets the localised URL. `/dtwap` is
+ * in the availability map as Korean-translated, so it prefixes.
+ */
+export const TranslatedPagePrefixesTheLocale: Story = {
+  args: {
+    id: 'footer-powered-by',
+    title: 'Powered by Orbs',
+    locale: 'ko',
+    items: [{ spec: spec('dtwap', '/dtwap'), label: 'dTWAP 프로토콜' }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('link', { name: 'dTWAP 프로토콜' })).toHaveAttribute('href', '/ko/dtwap/')
+  },
+}
+
+/**
+ * A page with no Korean version falls back to the English URL rather than
+ * minting `/ko/pos/`, which would be a second URL serving the same English page.
+ * Most of the footer is in this state until Phase 3 lands the pages.
+ */
+export const UntranslatedPageFallsBackToEnglishUrl: Story = {
+  args: {
+    id: 'footer-overview',
+    title: 'Overview',
+    locale: 'ko',
+    items: [{ spec: spec('proofOfStake', '/pos'), label: '지분증명(PoS V3)' }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByRole('link', { name: '지분증명(PoS V3)' })).toHaveAttribute('href', '/pos/')
+  },
+}
+
+/**
+ * There is no Japanese blog on this site, so the legacy Japanese footer links
+ * the community Medium publication instead. The override wins over `localeHref`
+ * and the link becomes external even though the entry it overrides is internal.
+ */
+export const LocaleOverrideSendsTheBlogOffSite: Story = {
+  args: {
+    id: 'footer-community',
+    title: 'Community',
+    locale: 'ja',
+    items: [
+      {
+        spec: spec('blog', '/blog', {
+          ja: 'https://orbs-japan-community.medium.com/',
+          ko: 'https://orbskorea.medium.com/',
+        }),
+        label: 'Blog',
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const link = canvas.getByRole('link', { name: 'Blog' })
+
+    await expect(link).toHaveAttribute('href', 'https://orbs-japan-community.medium.com/')
+    await expect(link).toHaveAttribute('target', '_blank')
+    await expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  },
+}
+
+/** English stays internal — the override is per-locale, not a replacement. */
+export const EnglishBlogStaysOnSite: Story = {
+  args: {
+    id: 'footer-community',
+    title: 'Community',
+    locale: 'en',
+    items: [
+      {
+        spec: spec('blog', '/blog', { ja: 'https://orbs-japan-community.medium.com/' }),
+        label: 'Blog',
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const link = canvas.getByRole('link', { name: 'Blog' })
+
+    await expect(link).toHaveAttribute('href', '/blog/')
+    await expect(link).not.toHaveAttribute('target')
+  },
+}
+
+/**
+ * An empty label means this locale's footer omits the link — the Japanese
+ * footer has no accessibility declaration. It must not render as a blank link.
+ */
+export const EmptyLabelIsSkipped: Story = {
+  args: {
+    id: 'footer-overview',
+    title: 'Overview',
+    locale: 'ja',
+    items: [
+      { spec: spec('faq', '/faq'), label: 'FAQ' },
+      { spec: spec('accessibility', '/accessibility-declaration'), label: '' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getAllByRole('link')).toHaveLength(1)
+  },
+}
+
+/** Whitespace-only labels count as empty too. */
+export const WhitespaceLabelIsSkipped: Story = {
+  args: {
+    id: 'footer-overview',
+    title: 'Overview',
+    locale: 'ja',
+    items: [{ spec: spec('accessibility', '/accessibility-declaration'), label: '   ' }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.queryAllByRole('link')).toHaveLength(0)
+  },
+}
+
+/**
+ * Korean chrome is a genuine mix: translated labels alongside brand nouns the
+ * legacy site left in English. The English ones are marked `lang="en"` so a
+ * screen reader does not read "Tetra" with Korean pronunciation rules.
+ */
+export const LatinLabelsAreMarkedEnglishInKorean: Story = {
+  args: {
+    id: 'footer-resources',
+    title: 'Resources',
+    locale: 'ko',
+    items: [
+      { spec: spec('tetra', 'https://staking.orbs.network/'), label: 'Tetra' },
+      { spec: spec('contact', '/contact'), label: '문의하기' },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByRole('link', { name: 'Tetra' })).toHaveAttribute('lang', 'en')
+    await expect(canvas.getByRole('link', { name: '문의하기' })).not.toHaveAttribute('lang')
+  },
+}

--- a/src/app/components/layout/footer/footer-nav.tsx
+++ b/src/app/components/layout/footer/footer-nav.tsx
@@ -1,0 +1,119 @@
+import Link from 'next/link'
+import { FooterLink1 } from '@/components/ui/footer-link'
+import type { FooterLinkSpec } from '@/content/shared/footer'
+import { localeHref } from '@/i18n/availability'
+import type { Locale } from '@/i18n/locales'
+import { textLang } from '@/i18n/script'
+
+/**
+ * A link with its label already resolved from the catalog.
+ *
+ * Labels are looked up once in `Footer` rather than in each column. That keeps
+ * every `getTranslations` call — and so every reason this tree would have to be
+ * async — at the one boundary that is already a server component, which is what
+ * lets the pieces below be plain functions with stories.
+ */
+export type FooterNavItem = {
+  spec: FooterLinkSpec
+  label: string
+}
+
+/**
+ * Where a footer link actually points in this locale, and whether that is off
+ * this site.
+ *
+ * Three cases, and the order matters. A per-locale override wins outright — the
+ * Japanese and Korean "Blog" entries go to Medium, and running those through
+ * `localeHref` would try to localise an absolute URL. Otherwise an absolute
+ * `href` is external and passes through untouched. Only an internal path reaches
+ * `localeHref`, which is the one case it is for.
+ *
+ * `external` is derived from the RESOLVED href rather than from the spec, so an
+ * override that points off-site is external even though the entry it overrides
+ * is internal. That is exactly the blog case: `/blog` is internal, its Japanese
+ * destination is not.
+ */
+export function resolveFooterHref(spec: FooterLinkSpec, locale: Locale): { href: string; external: boolean } {
+  const override = spec.localeHref?.[locale]
+
+  if (override !== undefined) {
+    return { href: override, external: !override.startsWith('/') }
+  }
+
+  if (!spec.href.startsWith('/')) {
+    return { href: spec.href, external: true }
+  }
+
+  return { href: localeHref(spec.href, locale), external: false }
+}
+
+/**
+ * One footer link, routed or not depending on where it goes.
+ *
+ * Internal links go through `next/link` via `asChild` so in-site navigation
+ * stays client-side; external ones are plain anchors opening in a new tab.
+ * `rel="noopener noreferrer"` on the external branch is not decoration — without
+ * `noopener` the opened page gets a handle on this one via `window.opener`.
+ */
+export function FooterNavLink({ label, locale, spec }: FooterNavItem & { locale: Locale }) {
+  const { href, external } = resolveFooterHref(spec, locale)
+  const lang = textLang(label, locale)
+
+  if (external) {
+    return (
+      <FooterLink1 href={href} target="_blank" rel="noopener noreferrer" lang={lang}>
+        {label}
+      </FooterLink1>
+    )
+  }
+
+  return (
+    <FooterLink1 asChild lang={lang}>
+      <Link href={href}>{label}</Link>
+    </FooterLink1>
+  )
+}
+
+/**
+ * A titled column of links.
+ *
+ * The column headings stay English in every locale because the legacy site left
+ * them that way — `title: POWERED BY ORBS` is identical in the Japanese and
+ * Korean footer files. They are still catalog entries rather than literals, so
+ * translating them later is a catalog edit and not a code change.
+ *
+ * An item whose label is empty is dropped. That is how this codebase expresses
+ * "this locale omits the link" (see `ArchitectureSection`): the Japanese footer
+ * has no accessibility declaration, and one shared column list with an empty
+ * catalog value says so without forking `FOOTER_COLUMNS` three ways.
+ */
+export function FooterNavColumn({
+  id,
+  title,
+  items,
+  locale,
+}: {
+  /** Ties the heading to its `<nav>` via `aria-labelledby`. */
+  id: string
+  title: string
+  items: readonly FooterNavItem[]
+  locale: Locale
+}) {
+  const visible = items.filter((item) => item.label.trim() !== '')
+
+  return (
+    <nav aria-labelledby={id}>
+      <h2 id={id} lang={textLang(title, locale)} className="text-detail font-semibold uppercase tracking-wide text-fg">
+        {title}
+      </h2>
+
+      <ul className="mt-4 space-y-3">
+        {visible.map((item) => (
+          <li key={item.spec.key}>
+            <FooterNavLink {...item} locale={locale} />
+          </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}

--- a/src/app/components/layout/footer/footer-socials.stories.tsx
+++ b/src/app/components/layout/footer/footer-socials.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { expect, within } from 'storybook/test'
+import { FOOTER_SOCIALS } from '@/content/shared/footer'
+import { FooterSocials } from './footer-socials'
+
+const meta = {
+  title: 'Layout/FooterSocials',
+  component: FooterSocials,
+} satisfies Meta<typeof FooterSocials>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const LABELS = {
+  github: 'GitHub',
+  x: 'X',
+  telegram: 'Telegram',
+  discord: 'Discord',
+  youtube: 'YouTube',
+  snapshot: 'Snapshot',
+}
+
+export const Default: Story = {
+  args: { labels: LABELS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getAllByRole('link')).toHaveLength(FOOTER_SOCIALS.length)
+  },
+}
+
+/**
+ * The only visible content is an SVG, so without the catalog label each link
+ * would announce as unlabelled. The icon components carry their own
+ * `role="img"` and `aria-label`, which is why they are hidden here — otherwise
+ * two names compete for one link.
+ */
+export const EveryLinkHasOneAccessibleName: Story = {
+  args: { labels: LABELS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    for (const social of FOOTER_SOCIALS) {
+      const link = canvas.getByRole('link', { name: LABELS[social.key as keyof typeof LABELS] })
+      await expect(link).toHaveAttribute('href', social.href)
+    }
+
+    // The glyphs are decorative here, so none of them expose an image role.
+    await expect(canvas.queryAllByRole('img')).toHaveLength(0)
+  },
+}
+
+/** Every social link leaves the site, so all of them need the safe rel. */
+export const AllLinksOpenSafelyInANewTab: Story = {
+  args: { labels: LABELS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    for (const link of canvas.getAllByRole('link')) {
+      await expect(link).toHaveAttribute('target', '_blank')
+      await expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    }
+  },
+}

--- a/src/app/components/layout/footer/footer-socials.tsx
+++ b/src/app/components/layout/footer/footer-socials.tsx
@@ -1,0 +1,64 @@
+import {
+  DiscordIcon,
+  GithubIcon,
+  type IconBaseProps,
+  SnapshotIcon,
+  TelegramIcon,
+  XIcon,
+  YoutubeIcon,
+} from '@/components/icons'
+import { FOOTER_SOCIALS, type FooterSocialSpec } from '@/content/shared/footer'
+
+/**
+ * Named rather than resolved by string at render, so a typo in the data file is
+ * a TypeScript error at build time instead of an undefined component.
+ */
+const ICONS: Record<FooterSocialSpec['icon'], React.ComponentType<IconBaseProps>> = {
+  github: GithubIcon,
+  x: XIcon,
+  telegram: TelegramIcon,
+  discord: DiscordIcon,
+  youtube: YoutubeIcon,
+  snapshot: SnapshotIcon,
+}
+
+/**
+ * The social row in the bottom bar.
+ *
+ * Each link needs an accessible name from the catalog because its only content
+ * is an SVG — without one a screen reader announces six unlabelled links. The
+ * names are brand nouns ("GitHub", "Discord") and identical in all three
+ * locales, so they are not passed through `textLang`: there is no locale in
+ * which they are anything but English, and marking them per-string would be the
+ * same answer every time.
+ */
+export function FooterSocials({ labels }: { labels: Record<string, string> }) {
+  return (
+    <ul className="flex items-center gap-5">
+      {FOOTER_SOCIALS.map((social) => {
+        const Icon = ICONS[social.icon]
+
+        return (
+          <li key={social.key}>
+            <a
+              href={social.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={labels[social.key]}
+              lang="en"
+              className="inline-flex text-fg-muted transition-colors hover:text-link"
+            >
+              {/*
+                Every icon component sets its own `role="img"` and `aria-label`.
+                Left alone that name would compete with the anchor's, so the
+                glyph is hidden and the link keeps the single accessible name
+                the catalog gives it.
+              */}
+              <Icon className="size-5" aria-hidden focusable="false" />
+            </a>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/src/app/components/layout/footer/footer.tsx
+++ b/src/app/components/layout/footer/footer.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link'
+import { getTranslations } from 'next-intl/server'
+import { OrbsLogo } from '@/components/icons'
+import { FooterLink2 } from '@/components/ui/footer-link'
+import { Prose } from '@/components/marketing/prose'
+import { FOOTER_COLUMNS, FOOTER_EMAIL, FOOTER_POLICY_LINKS, FOOTER_SOCIALS } from '@/content/shared/footer'
+import { localeHref } from '@/i18n/availability'
+import { localePath, type Locale } from '@/i18n/locales'
+import { textLang } from '@/i18n/script'
+import { FooterNavColumn } from './footer-nav'
+import { FooterSocials } from './footer-socials'
+
+/**
+ * The site footer, ported from the legacy `partials/footer/`.
+ *
+ * Two of the legacy sections are deliberately not here:
+ *
+ *  - **Subscribe.** A popup form posting to a mailing-list backend, which is #35
+ *    (Resend route handlers, Phase 4). Porting the markup without the handler
+ *    would ship a form that silently does nothing.
+ *  - **Latest tweets.** An embedded Twitter widget — a third-party script in the
+ *    chrome of all 456 prerendered pages. That is #33 (interactive widgets),
+ *    where its cost can be weighed on its own.
+ *
+ * The legacy "Latest Blog Posts" block is absent too. Unlike the other two it
+ * has no ticket, because it is not a port: it needs a Contentful fetch, and
+ * putting one in a component that renders on every page is a decision about the
+ * whole site's data flow rather than about the footer. Left for a follow-up.
+ *
+ * Every `t()` call in the footer tree happens here. The children take resolved
+ * strings, which is what keeps them synchronous and gives them stories — the
+ * repo's only test surface.
+ *
+ * The locale is a prop for the same reason as in `Header`: with no `[locale]`
+ * segment and no middleware, next-intl's hooks cannot resolve it from the
+ * request and quietly return English.
+ */
+export async function Footer({ locale }: { locale: Locale }) {
+  const t = await getTranslations({ locale, namespace: 'footer' })
+
+  const socialLabels = Object.fromEntries(FOOTER_SOCIALS.map((social) => [social.key, t(`socials.${social.key}`)]))
+
+  return (
+    <footer className="mt-20 border-t border-gray-200 dark:border-gray-800">
+      <div className="container mx-auto px-5 py-12">
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,20rem)_1fr]">
+          <section>
+            <Link href={localePath(locale, '/')} aria-label={t('homeLink')} className="inline-flex">
+              <OrbsLogo className="h-8 w-auto" />
+            </Link>
+
+            {/*
+              `Prose` renders paragraphs and bold, not links. The legacy blurb
+              links dLIMIT, dTWAP and Liquidity Hub inline; all three sit in the
+              Powered by Orbs column a few inches away, so the catalog copy drops
+              the inline markup rather than teaching the renderer link syntax for
+              a duplicate of an adjacent link.
+            */}
+            <Prose text={t('blurb')} className="mt-6 text-detail" />
+
+            <a
+              href={`mailto:${FOOTER_EMAIL}`}
+              className="mt-6 inline-flex text-detail font-medium text-fg-muted transition-colors hover:text-link"
+            >
+              {FOOTER_EMAIL}
+            </a>
+          </section>
+
+          <div className="grid grid-cols-2 gap-x-8 gap-y-10 sm:grid-cols-4">
+            {FOOTER_COLUMNS.map((column) => (
+              <FooterNavColumn
+                key={column.key}
+                id={`footer-${column.key}`}
+                title={t(`columns.${column.key}`)}
+                items={column.links.map((spec) => ({ spec, label: t(`links.${spec.key}`) }))}
+                locale={locale}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t border-gray-200 dark:border-gray-800">
+        <div className="container mx-auto flex flex-col-reverse items-center gap-6 px-5 py-6 sm:flex-row sm:justify-between">
+          <ul className="flex flex-wrap items-center justify-center gap-x-6 gap-y-2">
+            {FOOTER_POLICY_LINKS.map((spec) => ({ spec, label: t(`links.${spec.key}`) }))
+              // Same empty-label rule as the nav columns: the legacy Japanese
+              // footer carries Terms of Use and Privacy Policy but no
+              // accessibility declaration.
+              .filter(({ label }) => label.trim() !== '')
+              .map(({ spec, label }) => (
+                <li key={spec.key}>
+                  <FooterLink2 asChild lang={textLang(label, locale)}>
+                    <Link href={localeHref(spec.href, locale)}>{label}</Link>
+                  </FooterLink2>
+                </li>
+              ))}
+          </ul>
+
+          <FooterSocials labels={socialLabels} />
+        </div>
+      </div>
+    </footer>
+  )
+}

--- a/src/app/components/layout/footer/footer.tsx
+++ b/src/app/components/layout/footer/footer.tsx
@@ -55,7 +55,13 @@ export async function Footer({ locale }: { locale: Locale }) {
               lang={textLang(t('homeLink'), locale)}
               className="inline-flex"
             >
-              <OrbsLogo className="h-8 w-auto" />
+              {/*
+                `OrbsLogo` names itself "Orbs". Inside a link that already has
+                an `aria-label`, that is a second piece of content in one link —
+                the same redundancy the social icons avoid, so it is hidden the
+                same way and the link keeps one accessible name.
+              */}
+              <OrbsLogo className="h-8 w-auto" aria-hidden focusable="false" />
             </Link>
 
             {/*

--- a/src/app/components/layout/footer/footer.tsx
+++ b/src/app/components/layout/footer/footer.tsx
@@ -45,7 +45,16 @@ export async function Footer({ locale }: { locale: Locale }) {
       <div className="container mx-auto px-5 py-12">
         <div className="grid gap-12 lg:grid-cols-[minmax(0,20rem)_1fr]">
           <section>
-            <Link href={localePath(locale, '/')} aria-label={t('homeLink')} className="inline-flex">
+            <Link
+              href={localePath(locale, '/')}
+              aria-label={t('homeLink')}
+              // Same per-string rule as the header logo: `homeLink` is the
+              // English "Orbs home" in Japanese but "Orbs 홈" in Korean, so only
+              // one of them needs marking. Without it the Japanese document's
+              // `lang` applies Japanese pronunciation to an English name.
+              lang={textLang(t('homeLink'), locale)}
+              className="inline-flex"
+            >
               <OrbsLogo className="h-8 w-auto" />
             </Link>
 

--- a/src/app/components/layout/root-shell.tsx
+++ b/src/app/components/layout/root-shell.tsx
@@ -5,6 +5,7 @@ import '../../globals.css'
 import { getMessages } from 'next-intl/server'
 import { ThemeProvider } from 'next-themes'
 import { LOCALE_HTML_LANG, type Locale } from '@/i18n/locales'
+import { Footer } from './footer/footer'
 import { Header } from './header'
 
 const montserrat = Montserrat({ subsets: ['latin'], weight: ['400', '500', '600', '700', '900'] })
@@ -64,6 +65,7 @@ export async function RootShell({ locale, children }: { locale: Locale; children
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
             <Header locale={locale} />
             <main>{children}</main>
+            <Footer locale={locale} />
           </ThemeProvider>
         </NextIntlClientProvider>
       </body>

--- a/src/components/ui/footer-link.tsx
+++ b/src/components/ui/footer-link.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { Slot } from '@radix-ui/react-slot'
 
 import { cn } from '@/lib/utils'
 
@@ -6,6 +7,17 @@ type BaseProps = {
   href?: string
   active?: boolean
   className?: string
+  /**
+   * Render the child element with these styles instead of an `<a>`, the same
+   * `asChild` contract `Button` uses.
+   *
+   * Exists for internal links. Passing `href` renders a plain anchor, which is
+   * a full document load — fine for the external links that make up the
+   * Resources column, wrong for in-site navigation. `asChild` lets the caller
+   * supply a `next/link` and keep client-side routing and prefetching without
+   * this primitive having to know about the router.
+   */
+  asChild?: boolean
   children: React.ReactNode
 }
 
@@ -16,8 +28,28 @@ export type FooterLinkProps = AnchorProps | ButtonNativeProps
 
 function renderFooterLink(
   classes: string,
-  { href, active, children, ref, ...rest }: FooterLinkProps & { ref: React.Ref<HTMLAnchorElement | HTMLButtonElement> }
+  {
+    href,
+    active,
+    asChild,
+    children,
+    ref,
+    ...rest
+  }: FooterLinkProps & { ref: React.Ref<HTMLAnchorElement | HTMLButtonElement> }
 ) {
+  if (asChild) {
+    return (
+      <Slot
+        ref={ref as React.Ref<HTMLAnchorElement>}
+        aria-current={active ? 'page' : undefined}
+        className={classes}
+        {...(rest as React.AnchorHTMLAttributes<HTMLAnchorElement>)}
+      >
+        {children}
+      </Slot>
+    )
+  }
+
   if (href !== undefined) {
     return (
       <a

--- a/src/content/shared/footer.ts
+++ b/src/content/shared/footer.ts
@@ -1,0 +1,158 @@
+import type { Locale } from '@/i18n/locales'
+
+/**
+ * The footer's link structure, ported from the legacy `content/_shared/footer/`
+ * tree (four `navigation/<column>/index.md` files plus one file per link).
+ *
+ * Data only, and deliberately so: the labels live in the message catalogs under
+ * `footer.*`, keyed by the `key` fields here. The legacy site expressed the same
+ * split — one markdown file per link, per locale — and it is what lets the
+ * Korean column carry real translations while the Japanese one stays English
+ * without either needing a branch in the component.
+ *
+ * Internal `href`s are locale-INDEPENDENT and carry no trailing slash. Both
+ * matter: the component passes them through `localeHref`, which resolves the
+ * locale prefix from the availability map and appends the slash that
+ * `trailingSlash: true` requires. Writing `/jp/pos` here would defeat that and
+ * hardcode a prefix the map is supposed to own.
+ */
+export type FooterLinkSpec = {
+  /** Message key under the `footer.links` namespace. */
+  key: string
+  /**
+   * A locale-independent internal path (leading `/`, no trailing slash), or an
+   * absolute external URL. The `startsWith('/')` test decides which, matching
+   * `ArchitectureSection`.
+   */
+  href: string
+  /**
+   * Per-locale destination overrides, for links that go somewhere genuinely
+   * different rather than to a prefixed version of the same page.
+   *
+   * Only the blog needs this today, and it is not a translation detail: there is
+   * no Japanese or Korean blog on this site, so the legacy JP and KO footers
+   * link out to the community Medium publications instead. `localeHref` cannot
+   * express that — it maps a path to its localised URL, and the answer here is a
+   * different site.
+   */
+  localeHref?: Partial<Record<Locale, string>>
+}
+
+export type FooterColumnSpec = {
+  /** Message key under the `footer.columns` namespace. */
+  key: string
+  links: readonly FooterLinkSpec[]
+}
+
+/**
+ * The four navigation columns, in the legacy order.
+ *
+ * Most of these paths do not exist yet — only `/dtwap`, `/blog` and `/news` are
+ * built, so the rest 404 until Phase 3 lands them (#31, #32). That is deliberate
+ * and was decided explicitly: the footer ships at full legacy parity rather than
+ * hiding links behind a "is it built yet" check, because the alternative is a
+ * near-empty footer for the length of Phase 3 and a component API that has to be
+ * unpicked afterwards. Nothing is user-visible in the meantime — DNS still
+ * points at the legacy site (#39) — and the pre-cutover URL audit (#38) is the
+ * gate that catches any that are still dead.
+ */
+export const FOOTER_COLUMNS: readonly FooterColumnSpec[] = [
+  {
+    key: 'overview',
+    links: [
+      { key: 'whatIsOrbs', href: '/overview' },
+      { key: 'proofOfStake', href: '/pos' },
+      { key: 'executionServices', href: '/execution-services' },
+      { key: 'whitePapers', href: '/white-papers' },
+      { key: 'faq', href: '/faq' },
+    ],
+  },
+  {
+    key: 'poweredBy',
+    links: [
+      { key: 'liquidityHub', href: '/liquidity-hub' },
+      { key: 'perpetualHub', href: '/perpetual-hub' },
+      { key: 'dtwap', href: '/dtwap' },
+      { key: 'dlimit', href: '/dlimit' },
+      { key: 'dsltp', href: '/dsltp' },
+      { key: 'notifications', href: '/notifications' },
+      { key: 'tonAccess', href: '/ton-access' },
+      { key: 'tonVote', href: '/ton-vote' },
+    ],
+  },
+  {
+    key: 'resources',
+    links: [
+      { key: 'tetra', href: 'https://staking.orbs.network/' },
+      { key: 'stakingCalculator', href: 'https://www.stakingrewards.com/earn/orbs' },
+      // Legacy links this over plain HTTP. The host serves HTTPS (verified), and
+      // an insecure link in the chrome of every page is a mixed-content warning
+      // waiting to happen, so it is upgraded rather than copied faithfully.
+      { key: 'networkStatus', href: 'https://status.orbs.network/' },
+      { key: 'defiOrg', href: 'https://defi.org' },
+      { key: 'developers', href: 'https://docs.orbs.network/' },
+    ],
+  },
+  {
+    key: 'community',
+    links: [
+      {
+        key: 'blog',
+        href: '/blog',
+        localeHref: {
+          ja: 'https://orbs-japan-community.medium.com/',
+          ko: 'https://orbskorea.medium.com/',
+        },
+      },
+      { key: 'ecosystem', href: '/ecosystem' },
+      // `/news` is the legacy URL for press coverage and is labelled "Media".
+      { key: 'media', href: '/news' },
+      { key: 'brandAssets', href: '/brand-assets' },
+      { key: 'contact', href: '/contact' },
+    ],
+  },
+  // The legacy Community column also carried a Governance link to
+  // `/governance-blog`. Omitted on purpose: the governance blog is being deleted
+  // in the migration (plan §2.6, #30), so porting the link would mean shipping a
+  // pointer to something we are actively removing.
+]
+
+/**
+ * The bottom bar's policy links, in legacy order.
+ *
+ * Separate from the columns because they are a different kind of link — legal
+ * boilerplate rather than navigation — and the legacy footer renders them in a
+ * different place with different styling (`FooterLink2`, underlined on hover).
+ */
+export const FOOTER_POLICY_LINKS: readonly FooterLinkSpec[] = [
+  { key: 'termsOfUse', href: '/terms-of-use' },
+  { key: 'privacyPolicy', href: '/privacy-policy' },
+  { key: 'accessibility', href: '/accessibility-declaration' },
+]
+
+/**
+ * Social accounts, in the legacy order.
+ *
+ * `icon` names a component rather than an image path: the icons are already
+ * typed React components under `src/components/icons/socials/`, and they use
+ * `currentColor`, so they follow the footer's text colour into dark mode. The
+ * legacy site shipped six fixed grey SVGs that could not.
+ */
+export type FooterSocialSpec = {
+  /** Message key under `footer.socials`, used for the accessible label. */
+  key: string
+  icon: 'github' | 'x' | 'telegram' | 'discord' | 'youtube' | 'snapshot'
+  href: string
+}
+
+export const FOOTER_SOCIALS: readonly FooterSocialSpec[] = [
+  { key: 'github', icon: 'github', href: 'https://github.com/orbs-network/' },
+  { key: 'x', icon: 'x', href: 'https://twitter.com/orbs_network' },
+  { key: 'telegram', icon: 'telegram', href: 'https://t.me/OrbsNetwork' },
+  { key: 'discord', icon: 'discord', href: 'https://discord.gg/sswGDYGBt5' },
+  { key: 'youtube', icon: 'youtube', href: 'https://www.youtube.com/channel/UCfpV4z-MGxeiabFkht1LNPQ/featured' },
+  { key: 'snapshot', icon: 'snapshot', href: 'https://snapshot.org/#/orbs-network.eth' },
+]
+
+/** The contact address in the logo section. */
+export const FOOTER_EMAIL = 'hello@orbs.com'

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -19,6 +19,52 @@
     "getInTouch": "Get in Touch",
     "homeLink": "Orbs home"
   },
+  "footer": {
+    "homeLink": "Orbs home",
+    "blurb": "Orbs is a “Layer-3” public blockchain infrastructure project powered by PoS, pioneering on-chain innovation since 2017.\n\nOrbs is set up as a separate execution layer between L1/L2 solutions and the application layer, as part of a tiered blockchain stack, enhancing the capabilities of smart contracts and powering protocols such as dLIMIT, dTWAP and Liquidity Hub.",
+    "columns": {
+      "overview": "Overview",
+      "poweredBy": "Powered by Orbs",
+      "resources": "Resources",
+      "community": "Community"
+    },
+    "links": {
+      "whatIsOrbs": "What is Orbs: Layer 3",
+      "proofOfStake": "Proof of Stake",
+      "executionServices": "Execution Services",
+      "whitePapers": "White Papers",
+      "faq": "FAQ",
+      "liquidityHub": "Liquidity Hub",
+      "perpetualHub": "Perpetual Hub",
+      "dtwap": "dTWAP Protocol",
+      "dlimit": "dLIMIT Protocol",
+      "dsltp": "dSLTP Protocol",
+      "notifications": "Notification Protocol",
+      "tonAccess": "TON Access",
+      "tonVote": "TON Vote",
+      "tetra": "Tetra",
+      "stakingCalculator": "Staking Calculator",
+      "networkStatus": "Network Status",
+      "defiOrg": "DeFi.org",
+      "developers": "Developers",
+      "blog": "Blog",
+      "ecosystem": "Orbs Ecosystem",
+      "media": "Media",
+      "brandAssets": "Brand Assets",
+      "contact": "Contact",
+      "termsOfUse": "Terms of Use",
+      "privacyPolicy": "Privacy Policy",
+      "accessibility": "Accessibility Declaration"
+    },
+    "socials": {
+      "github": "GitHub",
+      "x": "X",
+      "telegram": "Telegram",
+      "discord": "Discord",
+      "youtube": "YouTube",
+      "snapshot": "Snapshot"
+    }
+  },
   "languageSelector": {
     "label": "Change language"
   },

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Japanese chrome is deliberately mostly English. The legacy site's jp/_shared/navbar menu links are English there too — every label in jp/_shared/navbar/menu-links/**/*.md is ASCII. The only genuinely translated Japanese chrome on the legacy site is the GDPR banner, the subscribe form, and the footer logo blurb, none of which exist in this codebase yet. Translating the nav here would invent copy the Japanese site has never shown, so these keys mirror English until real copy is supplied.",
+  "_note": "Japanese chrome is deliberately mostly English. The legacy site's jp/_shared/navbar menu links are English there too — every label in jp/_shared/navbar/menu-links/**/*.md is ASCII. The only genuinely translated Japanese chrome on the legacy site is the GDPR banner, the subscribe form, and the footer logo blurb; of those only \"footer.blurb\" exists here so far, and it carries the real legacy copy from jp/_shared/footer/logo-section.md rather than a new translation. Every other footer label is English because the legacy Japanese footer shows it in English. \"footer.links.accessibility\" is empty on purpose: that footer links Terms of Use and Privacy Policy only, and an empty label is how this codebase expresses an omitted link (see ArchitectureSection). Translating the nav here would invent copy the Japanese site has never shown, so these keys mirror English until real copy is supplied.",
   "nav": {
     "products": "Products",
     "resources": "Resources",
@@ -19,6 +19,52 @@
   "header": {
     "getInTouch": "Get in Touch",
     "homeLink": "Orbs home"
+  },
+  "footer": {
+    "homeLink": "Orbs home",
+    "blurb": "Orbsは、スケーラビリティや、低料金、仮想チェーン間の分離といった機能と共に、開発者エクスペリエンスや、オンラインIDE、使い慣れた言語でのスマートコントラクトを提供します。それにより、開発者が求めるパフォーマンスや、コスト、セキュリティ、使いやすさを組み合わせた最高のブロックチェーンを実現しました。",
+    "columns": {
+      "overview": "Overview",
+      "poweredBy": "Powered by Orbs",
+      "resources": "Resources",
+      "community": "Community"
+    },
+    "links": {
+      "whatIsOrbs": "What is Orbs: Layer 3",
+      "proofOfStake": "Proof of Stake",
+      "executionServices": "Execution Services",
+      "whitePapers": "White Papers",
+      "faq": "FAQ",
+      "liquidityHub": "Liquidity Hub",
+      "perpetualHub": "Perpetual Hub",
+      "dtwap": "dTWAP Protocol",
+      "dlimit": "dLIMIT Protocol",
+      "dsltp": "dSLTP Protocol",
+      "notifications": "Notification Protocol",
+      "tonAccess": "TON Access",
+      "tonVote": "TON Vote",
+      "tetra": "Tetra",
+      "stakingCalculator": "Staking Calculator",
+      "networkStatus": "Network Status",
+      "defiOrg": "DeFi.org",
+      "developers": "Developers",
+      "blog": "Blog",
+      "ecosystem": "Orbs Ecosystem",
+      "media": "Media",
+      "brandAssets": "Brand Assets",
+      "contact": "Contact",
+      "termsOfUse": "利用規約",
+      "privacyPolicy": "プライバシーポリシー",
+      "accessibility": ""
+    },
+    "socials": {
+      "github": "GitHub",
+      "x": "X",
+      "telegram": "Telegram",
+      "discord": "Discord",
+      "youtube": "YouTube",
+      "snapshot": "Snapshot"
+    }
   },
   "languageSelector": {
     "label": "言語を変更"

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -1,5 +1,5 @@
 {
-  "_note": "Korean values are lifted from the legacy site's ko/_shared/navbar/menu-links/**/*.md rather than newly translated. Keys left in English are ones the legacy Korean navbar also shows in English: the Resources and Developers menus are untranslated there, and the Products/Resources/Developers group headings have no legacy counterpart at all (the legacy menu groups are Overview/Protocols/Resources/Community). Those resolve when #30 replaces this placeholder nav with the real structure.",
+  "_note": "Korean values are lifted from the legacy site's ko/_shared/**/*.md rather than newly translated. Keys left in English are ones the legacy Korean site also shows in English: the Resources and Developers menus are untranslated there, in both the navbar and the footer, and \"footer.links.accessibility\" keeps the legacy footer's own English \"Accessibility declaration\". The Products/Resources/Developers group headings have no legacy counterpart at all (the legacy menu groups are Overview/Protocols/Resources/Community). Those resolve when #30 replaces this placeholder nav with the real structure. \"footer.blurb\" is the legacy ko/_shared/footer/logo-section.md copy with its inline dLIMIT/dTWAP/Liquidity Hub links dropped — Prose renders paragraphs and bold, not links, and all three targets sit in the adjacent Powered by Orbs column.",
   "nav": {
     "products": "Products",
     "resources": "Resources",
@@ -19,6 +19,52 @@
   "header": {
     "getInTouch": "문의하기",
     "homeLink": "Orbs 홈"
+  },
+  "footer": {
+    "homeLink": "Orbs 홈",
+    "blurb": "오브스는 2017년 설립되어 온체인 혁신을 이루어갑니다. 오브스 네트워크는 지분증명(PoS)에 의해 운영되는 “레이어-3” 공개형 블록체인 인프라 프로젝트입니다.\n\n오브스는 단계적으로 구성된 블록체인 스택의 일부로서 L1/L2 솔루션과 애플리케이션 레이어 사이에 추가적으로 실행을 담당하는 레이어를 구성하고 있으며, dLIMIT, dTWAP, 유동성 허브와 같이 스마트 컨트랙트의 기능을 훨씬 향상시키는 서비스들을 제공하고 있습니다.",
+    "columns": {
+      "overview": "Overview",
+      "poweredBy": "Powered by Orbs",
+      "resources": "Resources",
+      "community": "Community"
+    },
+    "links": {
+      "whatIsOrbs": "오브스: 레이어 3",
+      "proofOfStake": "지분증명(PoS V3)",
+      "executionServices": "블록체인 서비스",
+      "whitePapers": "백서 및 개발문서",
+      "faq": "FAQ",
+      "liquidityHub": "유동성 허브",
+      "perpetualHub": "선물 유동성 허브",
+      "dtwap": "dTWAP 프로토콜",
+      "dlimit": "dLIMIT 프로토콜",
+      "dsltp": "dSLTP 프로토콜",
+      "notifications": "DeFi 알림 프로토콜",
+      "tonAccess": "TON 액세스",
+      "tonVote": "TON Vote",
+      "tetra": "Tetra",
+      "stakingCalculator": "Staking Calculator",
+      "networkStatus": "Network Status",
+      "defiOrg": "DeFi.org",
+      "developers": "Developers",
+      "blog": "블로그",
+      "ecosystem": "오브스 생태계",
+      "media": "미디어",
+      "brandAssets": "브랜드 로고",
+      "contact": "문의하기",
+      "termsOfUse": "이용 약관",
+      "privacyPolicy": "개인정보정책",
+      "accessibility": "Accessibility declaration"
+    },
+    "socials": {
+      "github": "GitHub",
+      "x": "X",
+      "telegram": "Telegram",
+      "discord": "Discord",
+      "youtube": "YouTube",
+      "snapshot": "Snapshot"
+    }
   },
   "languageSelector": {
     "label": "언어 변경"


### PR DESCRIPTION
Every page has shipped without a footer since the migration started. This ports the legacy `partials/footer/` structure in all three locales: logo blurb, four navigation columns, policy links, socials.

Part of #29.

## Shape

Link structure is data (`src/content/shared/footer.ts`); labels live in the catalogs under `footer.*`. That mirrors how the legacy site split one markdown file per link per locale, and it's what lets the Korean column carry real translations while the Japanese one stays English — no branch in the component.

Internal hrefs are locale-independent and slashless. The component runs them through `localeHref`, so a page picks up its `/jp/` or `/ko/` prefix the moment it lands in the availability map. `/blog` is the one entry needing a per-locale *override* rather than a prefix: there is no Japanese or Korean blog here, so those footers link the community Medium publications, as the legacy ones do.

All `t()` calls happen in `Footer`; the children take resolved strings. That keeps them synchronous and gives them stories — the repo's only test surface.

## The dead links, deliberately

Most footer paths (`/overview`, `/pos`, `/white-papers`, `/faq`, `/liquidity-hub`, …) 404 until Phase 3 lands them. Shipping at full legacy parity was chosen over hiding links behind an "is it built" check: the alternative is a near-empty footer for the length of Phase 3 plus a component API to unpick afterwards. Nothing is user-visible — `www.orbs.com` still serves the legacy site — and #38's pre-cutover URL audit is the gate.

## Not ported

| Section | Why |
| --- | --- |
| Subscribe | Needs the Resend handler (#35). Markup alone is a dead form. |
| Latest tweets | Third-party script on all 456 pages; #33 weighs that. |
| Latest blog posts | Needs a Contentful fetch on every page — a data-flow decision, not a port. Follow-up. |

Governance is dropped from the Community column per plan §2.6 / #30 — the governance blog is being deleted.

## Supporting changes

- `FooterLink1`/`FooterLink2` gain `asChild` (same contract as `Button`) so internal links route via `next/link` rather than full document loads.
- Japanese omits the accessibility declaration. Expressed as an empty catalog value and filtered out, following the `ArchitectureSection` precedent from #72 rather than forking the structure per locale.
- Network Status upgraded to HTTPS. The host serves it, and an insecure link in every page's chrome is a mixed-content warning waiting to happen.
- `ja`/`ko` translator notes updated — both claimed the footer blurb didn't exist in this codebase yet. It does now, and `ja` uses the real legacy Japanese copy.

## Testing

- `npx vitest run` — 82 passed (12 new, covering internal vs external, locale prefixing, the English-URL fallback for untranslated pages, the blog override, empty-label skip, and the `lang="en"` marking of Latin labels in Korean).
- `npm run build` — clean; footer renders on all 456 prerendered posts.
- `npm run lint`, `npx tsc --noEmit` — clean.
- Verified rendered output on a production server for `/`, `/jp/` and `/ko/`: EN 34 links, JP 33 (accessibility correctly omitted) with the Japanese blurb and Medium blog, KO 34 with real translations and `/ko/dtwap/` prefixed while unbuilt pages fall back to English URLs.

**No visual review** — Playwright MCP isn't wired up in this environment, so the before/after screenshots the global convention asks for aren't available. Worth an eye on the Vercel preview.