### PR TITLE
fix: hide self-labelling icons inside already-labelled links

### DIFF
--- a/src/app/components/layout/header.tsx
+++ b/src/app/components/layout/header.tsx
@@ -36,7 +36,12 @@ export async function Header({ locale }: { locale: Locale }) {
             lang={textLang(t('homeLink'), locale)}
             className="text-xl font-bold text-gray-900 dark:text-white hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
           >
-            <OrbsLogo />
+            {/*
+              `OrbsLogo` names itself "Orbs". Inside a link that already has an
+              `aria-label` that is a second piece of content in one link, so the
+              glyph is hidden and the link keeps one accessible name.
+            */}
+            <OrbsLogo aria-hidden focusable="false" />
           </Link>
 
           <NavMenu locale={locale} />

--- a/src/components/marketing/product-hero.tsx
+++ b/src/components/marketing/product-hero.tsx
@@ -51,9 +51,25 @@ export function ProductHero({
               <Link href={ctaHref}>{ctaLabel}</Link>
             </Button>
 
-            {repo && <IconLink href={repo} label="GitHub repository" icon={<GithubIcon className="size-5" />} />}
+            {/*
+              The icons are hidden because `IconLink` labels the anchor itself.
+              Every social icon component sets its own `role="img"` and
+              `aria-label`, which would otherwise be a second accessible name
+              inside one link.
+            */}
+            {repo && (
+              <IconLink
+                href={repo}
+                label="GitHub repository"
+                icon={<GithubIcon className="size-5" aria-hidden focusable="false" />}
+              />
+            )}
             {telegram && (
-              <IconLink href={telegram} label="Telegram support group" icon={<TelegramIcon className="size-5" />} />
+              <IconLink
+                href={telegram}
+                label="Telegram support group"
+                icon={<TelegramIcon className="size-5" aria-hidden focusable="false" />}
+              />
             )}
           </div>
         </div>


### PR DESCRIPTION
Closes #84.

`OrbsLogo`, `GithubIcon` and `TelegramIcon` each set their own `role="img"` and `aria-label`. Nested inside a link that already carries an `aria-label`, that's a second piece of content in one link — the name gets announced twice.

Two sites, both turned up by the sweep #84 asked for:

- **`header.tsx`** — the logo, on every page.
- **`product-hero.tsx`** — the GitHub and Telegram links, on `/dtwap`.

Same treatment the footer's social icons already use (`aria-hidden focusable="false"`).

## Deliberately not changed

`home-hero.tsx:26` renders a standalone `OrbsLogo` that is *not* inside a labelled control. Its own name is the only one available there, so hiding it would make the hero graphic invisible to assistive tech. That's the case the icons' self-labelling default exists for, and it's why this is a call-site fix rather than a change to the icon components.

## Testing

- `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (82 passed) — clean.
- `npm run build` — clean.
- Verified against the production build: zero `role="img"` SVGs without `aria-hidden` on `/dtwap`; the only one remaining on `/` is the hero logo above.

No new stories — `ProductHero` and `Header` have no story files today, and standing one up for a two-attribute fix is the wrong shape. Worth folding regression coverage in when #29's remaining chrome work adds them.