### PR TITLE
fix(deps): bump qs to 6.16.0 to clear the remaining advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12636,9 +12636,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",


### PR DESCRIPTION
Last remaining `npm audit` finding on the root manifest. Clears GitHub alerts #231 and #232.

`qs` reaches production through `contentful-sdk-core@9.4.5`, a transitive of the `contentful` runtime dependency — so this is on the deployed path, not dev-only tooling.

## Lockfile hygiene note

Regenerated with **npm 11**, matching what CI's Node 24 ships. npm 10 strips the `libc` fields from optional platform binaries (`glibc`/`musl` constraints on esbuild, oxc-resolver et al), which turned a 3-line change into a 60-line diff that CI would immediately undo — and which could affect install correctness on musl. The committed diff is 3 lines: the `qs` entry only.

Worth knowing for anyone running `npm audit fix` here on Node 22.

## Verification

- `npm audit` — **0 vulnerabilities**, both with and without `--omit=dev`.
- `npx tsc --noEmit`, `npx vitest run` (82 passed), `npm run build` — clean.