### PR TITLE
feat: add mobile navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@contentful/rich-text-react-renderer": "^16.1.6",
+        "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-navigation-menu": "^1.2.14",
         "@radix-ui/react-separator": "^1.1.8",
@@ -2020,9 +2021,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2038,9 +2036,6 @@
       "integrity": "sha512-W7viwCk9JY/cAkdz/A273rd5bb3RgT/IHwR7Upv90tunjBWNtAAhGhoecHh+teRNRSinuAFmE+l7fwZ4YKkrXg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2058,9 +2053,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2076,9 +2068,6 @@
       "integrity": "sha512-H4mBso8ZTMBPtdT0PN0pBx2ayTvQuTuvS6qT13d77yVFJXAPCxkyIhLTmdMaGTJs0krQYI/qpzdHijCeihXhbg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2770,9 +2759,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2787,9 +2773,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2804,9 +2787,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2821,9 +2801,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2838,9 +2815,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2855,9 +2829,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2872,9 +2843,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2889,9 +2857,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3355,6 +3320,43 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.23.tgz",
+      "integrity": "sha512-Ksw4WeROkO4rC9k/onilX/Ao2Cr1ku1unMNH+XSCcP4jSXYu7HDsg9n4ojMjVb22XpYjAQ9qfrFlVbru1vXDUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-dismissable-layer": "1.1.19",
+        "@radix-ui/react-focus-guards": "1.1.6",
+        "@radix-ui/react-focus-scope": "1.1.16",
+        "@radix-ui/react-id": "1.1.4",
+        "@radix-ui/react-portal": "1.1.17",
+        "@radix-ui/react-presence": "1.1.10",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -4717,9 +4719,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4735,9 +4734,6 @@
       "integrity": "sha512-kKGBO9wdapiSzuf5ZzZ2fYtlu1BNSYtIIUxvH1ir/gcelTOREEHGDCLTDFx/2Knf878nU11A40z7LxwasEFxqA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -4755,9 +4751,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4773,9 +4766,6 @@
       "integrity": "sha512-4ji5PNzhYq193Z4/4xUaSoNJza6iCkDJSzhetrbB6KOYxsr+kxtQr8ePWhMJUiMt6JUWtXaZ1PYT8FhtED+nGA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
@@ -4793,9 +4783,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -4811,9 +4798,6 @@
       "integrity": "sha512-r9oV1mwxxsIGcLV1IQ/tw76MW3doatKze1QFWuC+a7QqJUkhY/bKTSVk6NpKKUGm2LDsE33Va8VqSClfA7vSiQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0 AND MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@contentful/rich-text-react-renderer": "^16.1.6",
+    "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-navigation-menu": "^1.2.14",
     "@radix-ui/react-separator": "^1.1.8",

--- a/scripts/visual-review.mjs
+++ b/scripts/visual-review.mjs
@@ -46,9 +46,13 @@ const THEMES = ['light', 'dark']
  * "run arbitrary steps" it is a test framework, and there is already one.
  */
 const SHOTS = {
-  'nav-products': { route: '/', open: 'Products' },
-  'nav-resources': { route: '/', open: 'Resources' },
-  'nav-developers': { route: '/', open: 'Developers' },
+  'nav-products': { route: '/', open: 'Products', viewport: 'desktop' },
+  'nav-resources': { route: '/', open: 'Resources', viewport: 'desktop' },
+  'nav-developers': { route: '/', open: 'Developers', viewport: 'desktop' },
+  // The mobile panel only exists below `lg`, so it has to be shot at the mobile
+  // viewport — the desktop-only rule this list started with would have skipped
+  // the one nav that most needed looking at (#96).
+  'nav-mobile': { route: '/', open: 'Open menu', viewport: 'mobile' },
 }
 
 function parseArgs(argv) {
@@ -181,10 +185,11 @@ async function capture(port, outDir, { routes, shots }) {
           process.stdout.write(`  ${file}\n`)
         }
 
-        // Interaction states are desktop-only: the dropdowns they open are not
-        // rendered at mobile widths, so capturing them there is an empty panel.
-        if (viewport.name === 'desktop') {
-          for (const name of shots) {
+        // Each shot names the viewport its control exists at: the dropdown bar
+        // is hidden below `lg` and the mobile panel above it, so shooting every
+        // shot at every width would capture a screenful of nothing half the time.
+        {
+          for (const name of shots.filter((n) => SHOTS[n].viewport === viewport.name)) {
             const shot = SHOTS[name]
             await load(page, `http://127.0.0.1:${port}${shot.route}`)
 

--- a/src/app/components/layout/header.tsx
+++ b/src/app/components/layout/header.tsx
@@ -73,8 +73,10 @@ export async function Header({ locale }: { locale: Locale }) {
               <MobileNav
                 groups={groups}
                 topLevel={topLevel}
+                locale={locale}
                 label={nav('menuLabel')}
                 title={nav('menuTitle')}
+                closeLabel={nav('menuClose')}
               />
             </div>
           </div>

--- a/src/app/components/layout/header.tsx
+++ b/src/app/components/layout/header.tsx
@@ -6,7 +6,9 @@ import { getTranslations } from 'next-intl/server'
 import Link from 'next/link'
 import { ThemeToggle } from '../theme/theme-toggle'
 import { LanguageSelector } from './language-selector'
-import { NavMenu } from './navigation/nav-menu'
+import { MobileNav } from './navigation/mobile-nav'
+import { NavMenuClient } from './navigation/nav-menu-client'
+import { resolveNavigation } from './navigation/nav-menu'
 
 /**
  * The locale arrives as a prop rather than from a next-intl hook.
@@ -23,6 +25,10 @@ import { NavMenu } from './navigation/nav-menu'
  */
 export async function Header({ locale }: { locale: Locale }) {
   const t = await getTranslations({ locale, namespace: 'header' })
+  const nav = await getTranslations({ locale, namespace: 'nav' })
+  // Resolved once and handed to both navs, so the desktop bar and the mobile
+  // panel cannot list different things.
+  const { groups, topLevel } = await resolveNavigation(locale)
 
   return (
     <nav className="border-b border-gray-200 dark:border-gray-800 bg-white/80 dark:bg-gray-950/80 backdrop-blur-sm sticky top-0 z-50">
@@ -45,14 +51,32 @@ export async function Header({ locale }: { locale: Locale }) {
             <OrbsLogo className="text-xl" aria-hidden />
           </Link>
 
-          <NavMenu locale={locale} />
+          {/*
+            The dropdown bar needs roughly 900px before it starts pushing the
+            header wider than the viewport, so it is hidden below `lg` and the
+            panel takes over. Without this the document laid out at 880px inside
+            a 390px viewport and every page scrolled sideways (#96).
+          */}
+          <div className="hidden lg:block">
+            <NavMenuClient groups={groups} topLevel={topLevel} />
+          </div>
 
           <div className="flex items-center gap-4">
             <ThemeToggle />
             <LanguageSelector />
-            <Button size="sm" lang={textLang(t('getInTouch'), locale)}>
+            <Button size="sm" className="hidden sm:inline-flex" lang={textLang(t('getInTouch'), locale)}>
               {t('getInTouch')}
             </Button>
+
+            {/* Counterpart to the dropdown bar's `hidden lg:block` above. */}
+            <div className="lg:hidden">
+              <MobileNav
+                groups={groups}
+                topLevel={topLevel}
+                label={nav('menuLabel')}
+                title={nav('menuTitle')}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/src/app/components/layout/navigation/mobile-nav.stories.tsx
+++ b/src/app/components/layout/navigation/mobile-nav.stories.tsx
@@ -39,8 +39,10 @@ const RESOURCES: ResolvedNavGroup = {
 const BASE = {
   groups: [PRODUCTS, RESOURCES],
   topLevel: [{ key: 'media', href: '/news/', external: false, label: 'Media' }],
+  locale: 'en' as const,
   label: 'Open menu',
   title: 'Menu',
+  closeLabel: 'Close',
 }
 
 /** Nothing is in the DOM until asked for — the trigger is the only control. */
@@ -131,5 +133,39 @@ export const ExternalRowsOpenSafely: Story = {
 
     await expect(external).toHaveAttribute('target', '_blank')
     await expect(external).toHaveAttribute('rel', 'noopener noreferrer')
+  },
+}
+
+/**
+ * The trigger, panel title and close control take the same per-string `lang`
+ * treatment as the menu rows. Korean translates the close control but leaves
+ * "Open menu" in English, so only one of them is marked — a blanket document
+ * `lang` would have a screen reader read the English one with Korean rules.
+ */
+export const LabelsCarryPerStringLang: Story = {
+  args: { ...BASE, locale: 'ko', label: 'Open menu', closeLabel: '닫기' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const trigger = canvas.getByRole('button', { name: 'Open menu' })
+
+    await expect(trigger).toHaveAttribute('lang', 'en')
+
+    await userEvent.click(trigger)
+    const dialog = await waitFor(() => within(document.body).getByRole('dialog'))
+
+    // Korean close label is genuinely Korean, so it carries no override.
+    await expect(within(dialog).getByText('닫기')).not.toHaveAttribute('lang')
+  },
+}
+
+/** The close control is named from the catalog, not shadcn's hardcoded English. */
+export const CloseControlIsTranslated: Story = {
+  args: { ...BASE, locale: 'ko', closeLabel: '닫기' },
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Open menu' }))
+
+    const dialog = await waitFor(() => within(document.body).getByRole('dialog'))
+    await expect(within(dialog).getByRole('button', { name: '닫기' })).toBeInTheDocument()
+    await expect(within(dialog).queryByRole('button', { name: 'Close' })).not.toBeInTheDocument()
   },
 }

--- a/src/app/components/layout/navigation/mobile-nav.stories.tsx
+++ b/src/app/components/layout/navigation/mobile-nav.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
+import { MobileNav } from './mobile-nav'
+import type { ResolvedNavGroup } from './nav-menu-client'
+
+const meta = {
+  title: 'Layout/MobileNav',
+  component: MobileNav,
+} satisfies Meta<typeof MobileNav>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const PRODUCTS: ResolvedNavGroup = {
+  key: 'products',
+  label: 'Products',
+  sections: [
+    {
+      key: 'infrastructure',
+      label: 'Infrastructure',
+      links: [{ key: 'liquidityHub', href: '/liquidity-hub/', external: false, label: 'Liquidity Hub' }],
+    },
+  ],
+}
+
+const RESOURCES: ResolvedNavGroup = {
+  key: 'resources',
+  label: 'Resources',
+  sections: [
+    { links: [{ key: 'blog', href: '/blog/', external: false, label: 'Blog' }] },
+    {
+      key: 'tools',
+      label: 'Tools',
+      links: [{ key: 'tetraWallet', href: 'https://staking.orbs.network/', external: true, label: 'Tetra Wallet' }],
+    },
+  ],
+}
+
+const BASE = {
+  groups: [PRODUCTS, RESOURCES],
+  topLevel: [{ key: 'media', href: '/news/', external: false, label: 'Media' }],
+  label: 'Open menu',
+  title: 'Menu',
+}
+
+/** Nothing is in the DOM until asked for — the trigger is the only control. */
+export const ClosedByDefault: Story = {
+  args: BASE,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByRole('button', { name: 'Open menu' })).toBeInTheDocument()
+    await expect(canvas.queryByRole('link', { name: 'Liquidity Hub' })).not.toBeInTheDocument()
+  },
+}
+
+/**
+ * Groups render OPEN rather than as accordions, matching the legacy mobile
+ * menu — with twelve links there is no reason to make someone tap twice to see
+ * a destination.
+ */
+export const OpensWithEveryGroupExpanded: Story = {
+  args: BASE,
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Open menu' }))
+
+    // The panel portals out of the canvas, so query the document.
+    const dialog = await waitFor(() => within(document.body).getByRole('dialog'))
+    const panel = within(dialog)
+
+    await expect(panel.getByRole('link', { name: 'Liquidity Hub' })).toBeInTheDocument()
+    await expect(panel.getByRole('link', { name: 'Blog' })).toBeInTheDocument()
+    await expect(panel.getByRole('link', { name: 'Tetra Wallet' })).toBeInTheDocument()
+    await expect(panel.getByRole('link', { name: 'Media' })).toBeInTheDocument()
+  },
+}
+
+/** The dialog carries an accessible name even though its title is visually hidden. */
+export const PanelIsNamed: Story = {
+  args: BASE,
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Open menu' }))
+    await waitFor(async () => {
+      await expect(within(document.body).getByRole('dialog', { name: 'Menu' })).toBeInTheDocument()
+    })
+  },
+}
+
+/**
+ * Following a link must close the panel. An internal link is a client-side
+ * transition, so without this the route changes underneath a panel that still
+ * covers it.
+ */
+export const ClosesWhenALinkIsFollowed: Story = {
+  args: BASE,
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Open menu' }))
+
+    const dialog = await waitFor(() => within(document.body).getByRole('dialog'))
+    await userEvent.click(within(dialog).getByRole('link', { name: 'Blog' }))
+
+    await waitFor(async () => {
+      await expect(within(document.body).queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  },
+}
+
+/** Escape closes it — the reason this is a Radix dialog rather than a div. */
+export const ClosesOnEscape: Story = {
+  args: BASE,
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Open menu' }))
+    await waitFor(() => within(document.body).getByRole('dialog'))
+
+    await userEvent.keyboard('{Escape}')
+
+    await waitFor(async () => {
+      await expect(within(document.body).queryByRole('dialog')).not.toBeInTheDocument()
+    })
+  },
+}
+
+/** External rows still open off-site safely. */
+export const ExternalRowsOpenSafely: Story = {
+  args: BASE,
+  play: async ({ canvasElement }) => {
+    await userEvent.click(within(canvasElement).getByRole('button', { name: 'Open menu' }))
+
+    const dialog = await waitFor(() => within(document.body).getByRole('dialog'))
+    const external = within(dialog).getByRole('link', { name: 'Tetra Wallet' })
+
+    await expect(external).toHaveAttribute('target', '_blank')
+    await expect(external).toHaveAttribute('rel', 'noopener noreferrer')
+  },
+}

--- a/src/app/components/layout/navigation/mobile-nav.tsx
+++ b/src/app/components/layout/navigation/mobile-nav.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { MenuIcon } from 'lucide-react'
+import Link from 'next/link'
+import { useState } from 'react'
+import { Separator } from '@/components/ui/separator'
+import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
+import { MenuItemW } from '@/components/ui/menu-item'
+import { GLYPHS, type ResolvedNavGroup, type ResolvedNavLink } from './nav-menu-client'
+
+/**
+ * The navigation for viewports too narrow for the dropdown bar.
+ *
+ * There was none. The header rendered the desktop nav at every width with no
+ * responsive rule, so below roughly 900px it overflowed and pushed the document
+ * wider than the viewport — at 390px the page laid out at 880px and every page
+ * scrolled sideways (#96).
+ *
+ * Structure follows the legacy mobile menu rather than inventing one: a panel
+ * with a close control and the groups listed OPEN, not as accordions. The
+ * legacy site made that choice with ~29 links; with twelve there is even less
+ * reason to make someone tap twice to see a destination.
+ *
+ * It renders from the same `ResolvedNavGroup` data as the desktop menu, so the
+ * two cannot drift — a link added to `NAV_GROUPS` appears in both or neither.
+ *
+ * `Sheet` (Radix Dialog) rather than a hand-rolled panel: an overlay nav needs
+ * a focus trap, Escape to close, background scroll lock and `aria-modal`, and
+ * hand-writing those is where accessibility bugs come from.
+ *
+ * It carries no breakpoint of its own. `Header` decides at which width each nav
+ * shows, which keeps that decision in one place next to the desktop bar's — and
+ * leaves this component renderable, and therefore testable, at any width.
+ */
+export function MobileNav({
+  groups,
+  topLevel,
+  label,
+  title,
+}: {
+  groups: readonly ResolvedNavGroup[]
+  topLevel: readonly ResolvedNavLink[]
+  /** Accessible name for the trigger — the button shows only an icon. */
+  label: string
+  /** Required by Radix Dialog: names the panel for assistive tech. */
+  title: string
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger
+        aria-label={label}
+        className="inline-flex size-9 items-center justify-center text-fg transition-colors hover:text-accent-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+      >
+        <MenuIcon className="size-5" aria-hidden focusable="false" />
+      </SheetTrigger>
+
+      <SheetContent side="right" className="w-[min(22rem,90vw)] overflow-y-auto">
+        {/*
+          Radix warns — and screen readers suffer — without a title on a dialog.
+          It is visually hidden because the panel's own heading is the groups
+          themselves; a visible "Menu" above them would be noise.
+        */}
+        <SheetTitle className="sr-only">{title}</SheetTitle>
+
+        <nav className="mt-8 flex flex-col gap-6">
+          {groups.map((group, groupIndex) => (
+            <div key={group.key}>
+              {groupIndex > 0 && <Separator className="mb-6" />}
+
+              <h2 lang={group.lang} className="text-detail font-semibold uppercase tracking-widest text-fg-muted">
+                {group.label}
+              </h2>
+
+              {group.sections.map((section, sectionIndex) => (
+                <div key={section.key ?? `section-${sectionIndex}`} className="mt-4">
+                  {section.label && (
+                    <h3
+                      lang={section.labelLang}
+                      className="mb-2 text-detail uppercase tracking-widest text-fg-muted"
+                    >
+                      [{section.label}]
+                    </h3>
+                  )}
+
+                  <ul className="space-y-1">
+                    {section.links.map((link) => (
+                      <li key={link.key}>
+                        <MobileNavRow link={link} onNavigate={() => setOpen(false)} />
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ))}
+            </div>
+          ))}
+
+          {topLevel.length > 0 && (
+            <>
+              <Separator />
+              <ul className="space-y-1">
+                {topLevel.map((link) => (
+                  <li key={link.key}>
+                    <MobileNavRow link={link} onNavigate={() => setOpen(false)} />
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </nav>
+      </SheetContent>
+    </Sheet>
+  )
+}
+
+/**
+ * Closing on navigation is not optional.
+ *
+ * An internal link is a client-side transition: without this the route changes
+ * underneath an open panel that still covers it, and the reader has to find the
+ * close button to see the page they asked for. External links open in a new tab,
+ * so the panel is closed for the same reason — this tab did not go anywhere, but
+ * leaving a menu open over it is still wrong.
+ */
+function MobileNavRow({ link, onNavigate }: { link: ResolvedNavLink; onNavigate: () => void }) {
+  const className = '-mx-2 flex w-full rounded-sm px-2 py-2.5 text-h5 tracking-normal hover:bg-accent hover:no-underline'
+  // Same map as the desktop rows: a product shows the same mark in both navs.
+  const Glyph = link.icon ? GLYPHS[link.icon] : undefined
+  const icon = Glyph ? <Glyph className="size-5" /> : undefined
+
+  if (link.external) {
+    return (
+      <MenuItemW
+        href={link.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        lang={link.lang}
+        icon={icon}
+        className={className}
+        onClick={onNavigate}
+      >
+        {link.label}
+      </MenuItemW>
+    )
+  }
+
+  return (
+    <MenuItemW asChild lang={link.lang} icon={icon} className={className}>
+      <Link href={link.href} onClick={onNavigate}>
+        {link.label}
+      </Link>
+    </MenuItemW>
+  )
+}

--- a/src/app/components/layout/navigation/mobile-nav.tsx
+++ b/src/app/components/layout/navigation/mobile-nav.tsx
@@ -6,6 +6,8 @@ import { useState } from 'react'
 import { Separator } from '@/components/ui/separator'
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 import { MenuItemW } from '@/components/ui/menu-item'
+import { textLang } from '@/i18n/script'
+import type { Locale } from '@/i18n/locales'
 import { GLYPHS, type ResolvedNavGroup, type ResolvedNavLink } from './nav-menu-client'
 
 /**
@@ -35,15 +37,28 @@ import { GLYPHS, type ResolvedNavGroup, type ResolvedNavLink } from './nav-menu-
 export function MobileNav({
   groups,
   topLevel,
+  locale,
   label,
   title,
+  closeLabel,
 }: {
   groups: readonly ResolvedNavGroup[]
   topLevel: readonly ResolvedNavLink[]
+  /**
+   * Needed to decide each label's `lang`.
+   *
+   * These three strings go through the same per-string rule as the menu rows:
+   * they are English in the Japanese catalog (as almost all Japanese chrome is)
+   * and translated in Korean, so a blanket document `lang` would have a screen
+   * reader pronounce "Open menu" with Japanese rules.
+   */
+  locale: Locale
   /** Accessible name for the trigger — the button shows only an icon. */
   label: string
   /** Required by Radix Dialog: names the panel for assistive tech. */
   title: string
+  /** Accessible name for the panel's close control. */
+  closeLabel: string
 }) {
   const [open, setOpen] = useState(false)
 
@@ -51,18 +66,26 @@ export function MobileNav({
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger
         aria-label={label}
+        lang={textLang(label, locale)}
         className="inline-flex size-9 items-center justify-center text-fg transition-colors hover:text-accent-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
       >
         <MenuIcon className="size-5" aria-hidden focusable="false" />
       </SheetTrigger>
 
-      <SheetContent side="right" className="w-[min(22rem,90vw)] overflow-y-auto">
+      <SheetContent
+        side="right"
+        className="w-[min(22rem,90vw)] overflow-y-auto"
+        closeLabel={closeLabel}
+        closeLang={textLang(closeLabel, locale)}
+      >
         {/*
           Radix warns — and screen readers suffer — without a title on a dialog.
           It is visually hidden because the panel's own heading is the groups
           themselves; a visible "Menu" above them would be noise.
         */}
-        <SheetTitle className="sr-only">{title}</SheetTitle>
+        <SheetTitle className="sr-only" lang={textLang(title, locale)}>
+          {title}
+        </SheetTitle>
 
         <nav className="mt-8 flex flex-col gap-6">
           {groups.map((group, groupIndex) => (

--- a/src/app/components/layout/navigation/nav-menu-client.tsx
+++ b/src/app/components/layout/navigation/nav-menu-client.tsx
@@ -24,8 +24,11 @@ import type { NavLinkSpec } from '@/content/shared/navigation'
  * Icon components cannot cross the server/client boundary, so the server passes
  * the icon's KEY and the map lives here. Named rather than resolved by string
  * at render, so a typo in the data file is a build error.
+ *
+ * Exported because the mobile panel renders the same rows and must show the
+ * same marks; a second copy of this map is a second thing to update.
  */
-const GLYPHS: Record<NonNullable<NavLinkSpec['icon']>, React.ComponentType<{ className?: string }>> = {
+export const GLYPHS: Record<NonNullable<NavLinkSpec['icon']>, React.ComponentType<{ className?: string }>> = {
   liquidityHub: LiquidityHubGlyph,
   perpetualHub: PerpetualHubGlyph,
   dlimit: DLimitGlyph,

--- a/src/app/components/layout/navigation/nav-menu.tsx
+++ b/src/app/components/layout/navigation/nav-menu.tsx
@@ -3,7 +3,7 @@ import { NAV_GROUPS, NAV_TOP_LEVEL_LINKS, type NavLinkSpec } from '@/content/sha
 import { localeHref } from '@/i18n/availability'
 import type { Locale } from '@/i18n/locales'
 import { textLang } from '@/i18n/script'
-import { NavMenuClient, type ResolvedNavLink } from './nav-menu-client'
+import type { ResolvedNavLink } from './nav-menu-client'
 
 /**
  * Where a menu link points in this locale, and whether that leaves the site.
@@ -22,7 +22,12 @@ function resolveNavHref(spec: NavLinkSpec, locale: Locale): { href: string; exte
 }
 
 /**
- * The header menu, resolved for one locale.
+ * The header menu's copy and destinations, resolved for one locale.
+ *
+ * Returns data rather than markup because two components render it — the
+ * desktop dropdown bar and the mobile panel (#96). Resolving once in `Header`
+ * and passing the result to both is what stops them drifting: a link added to
+ * `NAV_GROUPS` appears in both or in neither.
  *
  * Every `t()` call happens here and the rendering half is a client component,
  * because Radix's `NavigationMenu` needs state. Resolving labels there instead
@@ -49,7 +54,7 @@ function resolveNavHref(spec: NavLinkSpec, locale: Locale): { href: string; exte
  * segment and no middleware, next-intl's hooks cannot resolve it from the
  * request.
  */
-export async function NavMenu({ locale }: { locale: Locale }) {
+export async function resolveNavigation(locale: Locale) {
   const t = await getTranslations({ locale, namespace: 'nav' })
 
   const resolveLink = (spec: NavLinkSpec): ResolvedNavLink => {
@@ -86,5 +91,5 @@ export async function NavMenu({ locale }: { locale: Locale }) {
     }
   })
 
-  return <NavMenuClient groups={groups} topLevel={NAV_TOP_LEVEL_LINKS.map(resolveLink)} />
+  return { groups, topLevel: NAV_TOP_LEVEL_LINKS.map(resolveLink) }
 }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,140 @@
+"use client"
+
+import * as React from "react"
+import * as SheetPrimitive from "@radix-ui/react-dialog"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Sheet = SheetPrimitive.Root
+
+const SheetTrigger = SheetPrimitive.Trigger
+
+const SheetClose = SheetPrimitive.Close
+
+const SheetPortal = SheetPrimitive.Portal
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: {
+      side: "right",
+    },
+  }
+)
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = "right", className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+))
+SheetContent.displayName = SheetPrimitive.Content.displayName
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+SheetHeader.displayName = "SheetHeader"
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+SheetFooter.displayName = "SheetFooter"
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+))
+SheetTitle.displayName = SheetPrimitive.Title.displayName
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+SheetDescription.displayName = SheetPrimitive.Description.displayName
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -51,12 +51,22 @@ const sheetVariants = cva(
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
-    VariantProps<typeof sheetVariants> {}
+    VariantProps<typeof sheetVariants> {
+  /**
+   * Accessible name for the close control.
+   *
+   * Defaults to English so existing shadcn usage is unchanged, but localised
+   * callers must pass their own — this is the panel's only close affordance.
+   */
+  closeLabel?: string
+  /** `lang` for `closeLabel`, when it differs from the document. */
+  closeLang?: string
+}
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, children, closeLabel = "Close", closeLang, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
@@ -65,8 +75,18 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <X className="h-4 w-4" aria-hidden focusable="false" />
+        {/*
+          The label is a prop because this primitive is used inside localised
+          UI. shadcn ships it hardcoded to English, which made the mobile
+          menu's only close control announce as "Close" on `/ko/` — and, worse,
+          inherit the document's Korean, so a screen reader read an English
+          word with Korean pronunciation. `closeLang` carries the same
+          per-string `textLang` treatment the rest of the chrome uses.
+        */}
+        <span className="sr-only" lang={closeLang}>
+          {closeLabel}
+        </span>
       </SheetPrimitive.Close>
       {children}
     </SheetPrimitive.Content>

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -28,7 +28,8 @@
       "media": "Media"
     },
     "menuLabel": "Open menu",
-    "menuTitle": "Menu"
+    "menuTitle": "Menu",
+    "menuClose": "Close"
   },
   "header": {
     "getInTouch": "Get in Touch",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -26,7 +26,9 @@
       "tonVote": "TON Vote",
       "tonAccess": "TON Access",
       "media": "Media"
-    }
+    },
+    "menuLabel": "Open menu",
+    "menuTitle": "Menu"
   },
   "header": {
     "getInTouch": "Get in Touch",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -29,7 +29,8 @@
       "media": "Media"
     },
     "menuLabel": "Open menu",
-    "menuTitle": "Menu"
+    "menuTitle": "Menu",
+    "menuClose": "Close"
   },
   "header": {
     "getInTouch": "Get in Touch",

--- a/src/i18n/messages/ja.json
+++ b/src/i18n/messages/ja.json
@@ -27,7 +27,9 @@
       "tonVote": "TON Vote",
       "tonAccess": "TON Access",
       "media": "Media"
-    }
+    },
+    "menuLabel": "Open menu",
+    "menuTitle": "Menu"
   },
   "header": {
     "getInTouch": "Get in Touch",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -27,7 +27,9 @@
       "tonVote": "TON Vote",
       "tonAccess": "TON 액세스",
       "media": "미디어"
-    }
+    },
+    "menuLabel": "메뉴 열기",
+    "menuTitle": "메뉴"
   },
   "header": {
     "getInTouch": "문의하기",

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -29,7 +29,8 @@
       "media": "미디어"
     },
     "menuLabel": "메뉴 열기",
-    "menuTitle": "메뉴"
+    "menuTitle": "메뉴",
+    "menuClose": "닫기"
   },
   "header": {
     "getInTouch": "문의하기",


### PR DESCRIPTION
Closes #96.

There was no mobile navigation. The header rendered the desktop dropdown bar at **every** width with no responsive rule, so below roughly 900px it overflowed and pushed the document wider than the viewport.

**Measured, before and after:** at a 390x844 viewport the rendered document was **880px** wide — every page scrolled sideways. It is now **390px**.

## Structure

Follows the legacy mobile menu rather than inventing one: a panel with a close control and the groups listed **open**, not as accordions. The legacy site made that call with ~29 links; with twelve there's even less reason to make someone tap twice to reach a destination.

## One source of truth

`NavMenu` became `resolveNavigation`, returning the resolved groups rather than markup. `Header` resolves once and hands the result to both navs, so a link added to `NAV_GROUPS` appears in both or in neither. The product glyph map is exported and shared for the same reason — the marks match in both panels.

## Neither nav owns its breakpoint

`Header` decides which shows at which width (`hidden lg:block` / `lg:hidden`), keeping the two halves of one decision next to each other.

That wasn't cosmetic. With `lg:hidden` on the trigger itself, every story failed — the button was *correctly* absent from the accessibility tree at Storybook's width. Moving the breakpoint out made the component testable at any width, which is what the stories needed.

## New dependency

`@radix-ui/react-dialog`, via shadcn's `sheet`. An overlay nav needs a focus trap, Escape to close, background scroll lock and `aria-modal`. Hand-writing those is where accessibility bugs come from, and this is a component every mobile visitor touches.

## Script change

`scripts/visual-review.mjs` gains a `viewport` per interaction shot. It previously assumed desktop — which would have skipped the one nav that most needed looking at. `nav-mobile` now captures the open panel at 390px.

## Testing

- `npx vitest run` — 110 passed. Six new stories: closed by default, opens with every group expanded, the dialog is named despite a visually-hidden title, it closes when a link is followed (an internal link is a client-side transition, so otherwise the route changes underneath a panel still covering it), it closes on Escape, and external rows keep `target`/`rel`.
- `npm run build`, `npm run lint`, `npx tsc --noEmit` — clean.
- **Visual review**: home at 390px light and dark, plus the open panel. Header now fits, footer collapses to two columns, glyphs match desktop.

## Note

The "Get in Touch" button is `hidden sm:inline-flex` — at 390px the header would otherwise still be tight with logo, theme toggle, language selector, button *and* hamburger. It reappears at 640px. Flag if you'd rather it stayed at all widths and something else gave way.