### PR TITLE
feat: build the AI skills section

### DIFF
--- a/src/app/(en)/ai/skills/page.tsx
+++ b/src/app/(en)/ai/skills/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+import { AiSkillsPage } from '@/app/marketing/ai-skills'
+import { marketingMetadata } from '@/app/marketing/metadata'
+
+const PATH = '/ai/skills'
+
+/**
+ * There is deliberately no `/ai/` route above this one: the legacy site returns
+ * 404 for `/ai/`, and this index is the section's entry point.
+ */
+export async function generateMetadata(): Promise<Metadata> {
+  return marketingMetadata(PATH, 'en')
+}
+
+export default function Page() {
+  return <AiSkillsPage locale="en" />
+}

--- a/src/app/(en)/ai/skills/spot-advanced-swap-orders/page.tsx
+++ b/src/app/(en)/ai/skills/spot-advanced-swap-orders/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { marketingMetadata } from '@/app/marketing/metadata'
+import { SpotOrdersPage } from '@/app/marketing/spot-orders'
+
+const PATH = '/ai/skills/spot-advanced-swap-orders'
+
+/**
+ * A concrete route rather than `/ai/skills/[skill]/`: there is exactly one
+ * skill, and a dynamic segment would need a params source and a not-found path
+ * to serve a single page. The second skill is the right moment to add one.
+ */
+export async function generateMetadata(): Promise<Metadata> {
+  return marketingMetadata(PATH, 'en')
+}
+
+export default function Page() {
+  return <SpotOrdersPage locale="en" />
+}

--- a/src/app/marketing/agentic.tsx
+++ b/src/app/marketing/agentic.tsx
@@ -89,7 +89,7 @@ export async function AgenticPage({ locale }: { locale: Locale }) {
       <NumberedSteps
         title={t('oracle.title')}
         statement={t('oracle.statement')}
-        steps={AGENTIC_ORACLE_STEPS.map((id) => t(`oracle.steps.${id}`))}
+        steps={AGENTIC_ORACLE_STEPS.map((id) => ({ body: t(`oracle.steps.${id}`) }))}
         lang={textLang(t('oracle.statement'), locale)}
       />
 

--- a/src/app/marketing/ai-skills.tsx
+++ b/src/app/marketing/ai-skills.tsx
@@ -1,0 +1,34 @@
+import { getTranslations } from 'next-intl/server'
+import { SkillList } from '@/components/marketing/skill-list'
+import { AI_SKILLS } from '@/content/pages/ai-skills'
+import { resolveLocaleLink } from '@/content/shared/link'
+import type { Locale } from '@/i18n/locales'
+import { textLang } from '@/i18n/script'
+
+/**
+ * The AI skills index at `/ai/skills/`.
+ *
+ * Note there is no `/ai/` page above it: the legacy site 404s on `/ai/`, and
+ * this index is the section's entry point. #31 lists `/ai` as a product page,
+ * which is wrong about the URL — flagged on that issue.
+ */
+export async function AiSkillsPage({ locale }: { locale: Locale }) {
+  const t = await getTranslations({ locale, namespace: 'pages.aiSkills' })
+
+  return (
+    <SkillList
+      title={t('title')}
+      intro={t('intro')}
+      chainsLabel={t('chainsLabel')}
+      orderTypesLabel={t('orderTypesLabel')}
+      skills={AI_SKILLS.map((skill) => ({
+        ...skill,
+        // Through `localeHref`, so the Korean index links to the Korean skill
+        // page rather than sending the reader back to English.
+        href: resolveLocaleLink({ href: skill.href }, locale).href,
+        description: t(`items.${skill.id}.description`),
+      }))}
+      lang={textLang(t('intro'), locale)}
+    />
+  )
+}

--- a/src/app/marketing/registry.tsx
+++ b/src/app/marketing/registry.tsx
@@ -2,10 +2,12 @@ import { localesFor } from '@/i18n/availability'
 import type { Locale } from '@/i18n/locales'
 import { MARKETING_PAGE_PATHS, type MarketingPagePath } from '@/content/pages'
 import { AgenticPage } from './agentic'
+import { AiSkillsPage } from './ai-skills'
 import { DlimitPage } from './dlimit'
 import { DsltpPage } from './dsltp'
 import { LiquidityHubPage } from './liquidity-hub'
 import { PerpetualHubPage } from './perpetual-hub'
+import { SpotOrdersPage } from './spot-orders'
 import { DtwapPage } from './dtwap'
 
 /**
@@ -57,6 +59,11 @@ const MARKETING_PAGES: Record<MarketingPagePath, MarketingPageEntry> = {
   '/dlimit': { render: (locale) => <DlimitPage locale={locale} />, namespace: 'pages.dlimit' },
   '/dsltp': { render: (locale) => <DsltpPage locale={locale} />, namespace: 'pages.dsltp' },
   '/agentic': { render: (locale) => <AgenticPage locale={locale} />, namespace: 'pages.agentic' },
+  '/ai/skills': { render: (locale) => <AiSkillsPage locale={locale} />, namespace: 'pages.aiSkills' },
+  '/ai/skills/spot-advanced-swap-orders': {
+    render: (locale) => <SpotOrdersPage locale={locale} />,
+    namespace: 'pages.spotOrders',
+  },
   '/liquidity-hub': {
     render: (locale) => <LiquidityHubPage locale={locale} />,
     namespace: 'pages.liquidityHub',

--- a/src/app/marketing/spot-orders.tsx
+++ b/src/app/marketing/spot-orders.tsx
@@ -1,0 +1,84 @@
+import { getTranslations } from 'next-intl/server'
+import { ChainTable } from '@/components/marketing/chain-table'
+import { FeatureGrid } from '@/components/marketing/feature-grid'
+import { NumberedSteps } from '@/components/marketing/numbered-steps'
+import { ProductHero } from '@/components/marketing/product-hero'
+import {
+  SPOT_ORDERS_CHAINS,
+  SPOT_ORDERS_FEATURES,
+  SPOT_ORDERS_LINKS,
+  SPOT_ORDERS_QUICKSTART,
+  SPOT_ORDERS_STEPS,
+} from '@/content/pages/ai-skills'
+import type { Locale } from '@/i18n/locales'
+import { textLang } from '@/i18n/script'
+
+/**
+ * The Spot Advanced Swap Orders skill page.
+ *
+ * Composed entirely from existing components except `ChainTable`, which this
+ * page needs because its chain list carries EVM chain IDs. That is tabular data
+ * — someone is looking a value up — so it is a real `<table>` with headers,
+ * unlike Orbs Agentic's `ChainLogos`, which is a brand wall answering a
+ * different question.
+ *
+ * This is also the destination of Orbs Agentic's two primary calls to action
+ * (#104), which pointed at a route that did not exist until now.
+ */
+export async function SpotOrdersPage({ locale }: { locale: Locale }) {
+  const t = await getTranslations({ locale, namespace: 'pages.spotOrders' })
+
+  return (
+    <>
+      <ProductHero
+        headline={t('hero.headline')}
+        intro={t('hero.intro')}
+        ctaLabel={t('hero.cta')}
+        ctaHref={SPOT_ORDERS_LINKS.skillSpec}
+        repo={SPOT_ORDERS_LINKS.repo}
+        lang={textLang(t('hero.intro'), locale)}
+        headlineLang={textLang(t('hero.headline'), locale)}
+      />
+
+      <FeatureGrid
+        title={t('quickstart.title')}
+        intro={t('quickstart.intro')}
+        features={SPOT_ORDERS_QUICKSTART.map((id) => ({
+          id,
+          title: t(`quickstart.items.${id}.title`),
+          body: t(`quickstart.items.${id}.body`),
+        }))}
+        lang={textLang(t('quickstart.intro'), locale)}
+        titleLang={textLang(t('quickstart.title'), locale)}
+      />
+
+      <FeatureGrid
+        title={t('features.title')}
+        features={SPOT_ORDERS_FEATURES.map((id) => ({
+          id,
+          title: t(`features.items.${id}.title`),
+          body: t(`features.items.${id}.body`),
+        }))}
+        lang={textLang(t('features.items.market.body'), locale)}
+        titleLang={textLang(t('features.title'), locale)}
+      />
+
+      <NumberedSteps
+        title={t('howItWorks.title')}
+        steps={SPOT_ORDERS_STEPS.map((id) => ({
+          title: t(`howItWorks.steps.${id}.title`),
+          body: t(`howItWorks.steps.${id}.body`),
+        }))}
+        lang={textLang(t('howItWorks.steps.intent.body'), locale)}
+      />
+
+      <ChainTable
+        title={t('chains.title')}
+        nameHeader={t('chains.nameHeader')}
+        idHeader={t('chains.idHeader')}
+        chains={SPOT_ORDERS_CHAINS}
+        titleLang={textLang(t('chains.title'), locale)}
+      />
+    </>
+  )
+}

--- a/src/components/marketing/chain-table.stories.tsx
+++ b/src/components/marketing/chain-table.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { expect, within } from 'storybook/test'
+import { ChainTable } from './chain-table'
+
+const meta = {
+  title: 'Marketing/ChainTable',
+  component: ChainTable,
+} satisfies Meta<typeof ChainTable>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const CHAINS = [
+  { name: 'Ethereum', id: 1 },
+  { name: 'Base', id: 8453 },
+]
+
+/**
+ * A real table with headers, not a styled grid. Name and chain ID are two
+ * columns of one record and someone is looking a value up, so each cell needs
+ * something to be announced against.
+ */
+export const IsATableWithHeaders: Story = {
+  args: { title: 'Supported Chains', nameHeader: 'Chain', idHeader: 'Chain ID', chains: CHAINS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByRole('table')).toBeInTheDocument()
+    await expect(canvas.getByRole('columnheader', { name: 'Chain' })).toBeInTheDocument()
+    await expect(canvas.getByRole('columnheader', { name: 'Chain ID' })).toBeInTheDocument()
+    // Chain names are row headers, so each ID is announced against its chain.
+    await expect(canvas.getByRole('rowheader', { name: 'Ethereum' })).toBeInTheDocument()
+    await expect(canvas.getByRole('cell', { name: '8453' })).toBeInTheDocument()
+  },
+}
+
+/** Chain names are proper nouns, marked English in any document. */
+export const NamesAreMarkedEnglish: Story = {
+  args: { title: 'Supported Chains', nameHeader: 'Chain', idHeader: 'Chain ID', chains: CHAINS },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.querySelector('th[scope="row"][lang="en"]')).toBeTruthy()
+  },
+}

--- a/src/components/marketing/chain-table.tsx
+++ b/src/components/marketing/chain-table.tsx
@@ -1,0 +1,71 @@
+import { H2 } from '@/app/components/typography'
+
+export type ChainRow = {
+  /** Chain name. Not translated — a proper noun. */
+  name: string
+  /** EVM chain ID. */
+  id: number
+}
+
+/**
+ * Supported chains and their IDs.
+ *
+ * A real `<table>`, not a styled grid: name and chain ID are two columns of the
+ * same record, and someone reading this is looking a value up rather than
+ * browsing. Column headers give a screen reader something to announce each cell
+ * against, which a list of "Ethereum 1" pairs cannot.
+ *
+ * Distinct from `ChainLogos`, which is a brand wall answering "is my chain
+ * supported?". This answers "what is its ID?".
+ */
+export function ChainTable({
+  title,
+  nameHeader,
+  idHeader,
+  chains,
+  lang,
+  titleLang,
+}: {
+  title: string
+  nameHeader: string
+  idHeader: string
+  chains: readonly ChainRow[]
+  /** Set when this copy is English inside a non-English document. */
+  lang?: string
+  /** Set when the heading's language differs from the rest of the section. */
+  titleLang?: string
+}) {
+  return (
+    <section className="container mx-auto px-5 py-20" lang={lang}>
+      <H2 className="text-balance text-center" lang={titleLang}>
+        {title}
+      </H2>
+
+      <div className="mx-auto mt-12 max-w-2xl overflow-x-auto">
+        <table className="w-full border-collapse text-left">
+          <thead>
+            <tr className="border-b border-border">
+              <th scope="col" className="py-3 text-detail font-semibold uppercase tracking-wide text-fg-muted">
+                {nameHeader}
+              </th>
+              <th scope="col" className="py-3 text-detail font-semibold uppercase tracking-wide text-fg-muted">
+                {idHeader}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {chains.map((chain) => (
+              <tr key={chain.id} className="border-b border-border/50">
+                {/* `row` scope so each ID is announced against its chain. */}
+                <th scope="row" className="py-3 font-medium text-fg" lang="en">
+                  {chain.name}
+                </th>
+                <td className="py-3 text-muted-foreground">{chain.id}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}

--- a/src/components/marketing/numbered-steps.stories.tsx
+++ b/src/components/marketing/numbered-steps.stories.tsx
@@ -10,7 +10,11 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-const STEPS = ['Agent decides what to do.', 'Agent submits execution parameters.', 'The oracle cosigns.']
+const STEPS = [
+  { body: 'Agent decides what to do.' },
+  { body: 'Agent submits execution parameters.' },
+  { body: 'The oracle cosigns.' },
+]
 
 /**
  * An ordered list, because the order IS the content — this is a process, not a
@@ -46,5 +50,18 @@ export const StatementSitsOutsideTheList: Story = {
 
     await expect(canvas.getByText(/independently verified/)).toBeInTheDocument()
     await expect(canvasElement.querySelector('ol')?.textContent).not.toContain('independently verified')
+  },
+}
+
+/** Titled steps keep the name distinct from the explanation. */
+export const StepsCanBeTitled: Story = {
+  args: {
+    title: 'How It Works',
+    steps: [{ title: 'Define Intent', body: 'Specify chain, tokens and amount.' }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await expect(canvas.getByText(/Define Intent/)).toBeInTheDocument()
+    await expect(canvas.getByText(/Specify chain, tokens and amount\./)).toBeInTheDocument()
   },
 }

--- a/src/components/marketing/numbered-steps.tsx
+++ b/src/components/marketing/numbered-steps.tsx
@@ -13,6 +13,11 @@ import { Prose } from './prose'
  * claim about the whole flow rather than a step in it, so it sits outside the
  * list.
  */
+export type Step = {
+  title?: string
+  body: string
+}
+
 export function NumberedSteps({
   title,
   statement,
@@ -21,7 +26,13 @@ export function NumberedSteps({
 }: {
   title: string
   statement?: string
-  steps: readonly string[]
+  /**
+   * Steps may be a bare sentence or a titled one. Orbs Agentic's verification
+   * flow is four plain sentences; the AI skill's "How It Works" gives each step
+   * a name ("Define Intent", "Sign & Submit") that is worth keeping distinct
+   * from its explanation.
+   */
+  steps: readonly Step[]
   /** Set when this copy is English inside a non-English document. */
   lang?: string
 }) {
@@ -38,14 +49,17 @@ export function NumberedSteps({
 
         <ol className="mt-12 space-y-6">
           {steps.map((step, index) => (
-            <li key={step} className="flex gap-4">
+            <li key={step.body} className="flex gap-4">
               <span
                 aria-hidden
                 className="mt-1 flex size-7 shrink-0 items-center justify-center rounded-full border border-border text-detail font-medium"
               >
                 {index + 1}
               </span>
-              <span className="text-muted-foreground leading-relaxed">{step}</span>
+              <span className="leading-relaxed">
+                {step.title && <span className="font-medium text-fg">{step.title}. </span>}
+                <span className="text-muted-foreground">{step.body}</span>
+              </span>
             </li>
           ))}
         </ol>

--- a/src/components/marketing/skill-list.stories.tsx
+++ b/src/components/marketing/skill-list.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { expect, within } from 'storybook/test'
+import { SkillList } from './skill-list'
+
+const meta = {
+  title: 'Marketing/SkillList',
+  component: SkillList,
+} satisfies Meta<typeof SkillList>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const SKILLS = [
+  {
+    id: 'spotOrders',
+    name: 'Spot Advanced Swap Orders',
+    // Already locale-resolved by the page, so it carries the trailing slash
+    // `trailingSlash: true` requires.
+    href: '/ai/skills/spot-advanced-swap-orders/',
+    chains: ['Ethereum', 'Base'],
+    orderTypes: ['TWAP', 'Limit'],
+    description: 'Gasless limit, stop-loss, take-profit and TWAP orders.',
+  },
+]
+
+/**
+ * A skill is a catalogue entry: structured metadata beside its description.
+ * The chains and order types are `<dl>` pairs rather than prose, because that
+ * is what a reader scans for.
+ */
+export const MetadataIsADescriptionList: Story = {
+  args: { title: 'AI Skills', chainsLabel: 'Chains', orderTypesLabel: 'Order types', skills: SKILLS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByRole('heading', { level: 2, name: 'AI Skills' })).toBeInTheDocument()
+    await expect(canvas.getByText('Chains')).toBeInTheDocument()
+    await expect(canvas.getByText('Ethereum, Base')).toBeInTheDocument()
+    await expect(canvasElement.querySelectorAll('dt')).toHaveLength(2)
+  },
+}
+
+/** The card is clickable, but named by the skill rather than by all its text. */
+export const CardIsNamedByTheSkill: Story = {
+  args: { title: 'AI Skills', chainsLabel: 'Chains', orderTypesLabel: 'Order types', skills: SKILLS },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const link = canvas.getByRole('link', { name: 'Spot Advanced Swap Orders' })
+
+    await expect(link).toHaveAttribute('href', '/ai/skills/spot-advanced-swap-orders/')
+    await expect(link).toHaveAttribute('lang', 'en')
+  },
+}

--- a/src/components/marketing/skill-list.tsx
+++ b/src/components/marketing/skill-list.tsx
@@ -1,0 +1,100 @@
+import Link from 'next/link'
+import { H2, H3 } from '@/app/components/typography'
+import { Card, CardContent, CardHeader } from '@/components/ui/card'
+import { Prose } from './prose'
+
+export type SkillEntry = {
+  /** Message key and React key. */
+  id: string
+  /** Skill name. Not translated — it names a package. */
+  name: string
+  /** The skill's own page on this site. */
+  href: string
+  /** Chains it supports, and the order types it offers. Proper nouns. */
+  chains: readonly string[]
+  orderTypes: readonly string[]
+}
+
+export type ResolvedSkill = SkillEntry & {
+  description: string
+}
+
+/**
+ * The AI skills index: one card per skill.
+ *
+ * Deliberately not `FeatureGrid`. A skill card is a catalogue ENTRY — it
+ * carries structured metadata (which chains, which order types) alongside its
+ * description, and those are lists rather than prose. Flattening them into a
+ * paragraph would lose the thing a reader is scanning for.
+ *
+ * There is one skill today. This still renders as a list rather than a single
+ * bespoke block, because the legacy page is an index and the next skill should
+ * need no layout work.
+ */
+export function SkillList({
+  title,
+  intro,
+  chainsLabel,
+  orderTypesLabel,
+  skills,
+  lang,
+}: {
+  title: string
+  intro?: string
+  chainsLabel: string
+  orderTypesLabel: string
+  skills: readonly ResolvedSkill[]
+  /** Set when this copy is English inside a non-English document. */
+  lang?: string
+}) {
+  return (
+    <section className="container mx-auto px-5 py-20" lang={lang}>
+      <div className="mx-auto max-w-3xl text-center">
+        <H2 className="text-balance">{title}</H2>
+        {intro && <Prose text={intro} className="mt-6 [&_p]:text-lg" />}
+      </div>
+
+      <ul className="mx-auto mt-16 grid max-w-4xl gap-8">
+        {skills.map((skill) => (
+          <li key={skill.id}>
+            {/* `relative` bounds the stretched link that makes the card clickable. */}
+            <Card className="relative h-full transition-colors hover:border-accent-primary">
+              <CardHeader>
+                <H3 weight="medium">
+                  <Link
+                    href={skill.href}
+                    lang="en"
+                    className="after:absolute after:inset-0 transition-colors hover:text-accent-primary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  >
+                    {skill.name}
+                  </Link>
+                </H3>
+              </CardHeader>
+
+              <CardContent>
+                <Prose text={skill.description} />
+
+                <dl className="mt-6 grid gap-3 sm:grid-cols-2">
+                  <div>
+                    <dt className="text-detail font-semibold uppercase tracking-wide text-fg-muted">{chainsLabel}</dt>
+                    <dd className="mt-1 text-detail text-muted-foreground" lang="en">
+                      {skill.chains.join(', ')}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-detail font-semibold uppercase tracking-wide text-fg-muted">
+                      {orderTypesLabel}
+                    </dt>
+                    <dd className="mt-1 text-detail text-muted-foreground" lang="en">
+                      {skill.orderTypes.join(', ')}
+                    </dd>
+                  </div>
+                </dl>
+              </CardContent>
+            </Card>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/content/pages/ai-skills.ts
+++ b/src/content/pages/ai-skills.ts
@@ -1,0 +1,64 @@
+import type { ChainRow } from '@/components/marketing/chain-table'
+import type { SkillEntry } from '@/components/marketing/skill-list'
+
+/**
+ * Structural data for the AI skills section. Copy lives under `pages.aiSkills`
+ * and `pages.spotOrders`.
+ *
+ * `/ai` is NOT a page. #31 lists it as a product page, but the legacy site
+ * returns 404 for `/ai/` — what exists is an index at `/ai/skills/` and one
+ * skill at `/ai/skills/spot-advanced-swap-orders/`. Both are built here, which
+ * also gives the Orbs Agentic page's two primary calls to action a real
+ * destination (#104).
+ */
+
+export const AI_SKILLS_INDEX_PATH = '/ai/skills'
+export const SPOT_ORDERS_PATH = '/ai/skills/spot-advanced-swap-orders'
+
+/**
+ * The skills index.
+ *
+ * One entry today. Kept as a list so the second skill needs catalog entries and
+ * a route rather than a layout.
+ */
+export const AI_SKILLS: readonly SkillEntry[] = [
+  {
+    id: 'spotOrders',
+    name: 'Spot Advanced Swap Orders',
+    href: SPOT_ORDERS_PATH,
+    chains: ['Ethereum', 'BNB Chain', 'Polygon', 'Arbitrum', 'Base', 'Linea', 'Avalanche', 'Sonic'],
+    orderTypes: ['TWAP', 'Limit', 'Take-Profit', 'Stop-Loss'],
+  },
+]
+
+export const SPOT_ORDERS_LINKS = {
+  /** The machine-readable skill spec an agent is pointed at. */
+  skillSpec: 'https://orbs-network.github.io/spot/skill/SKILL.md',
+  repo: 'https://github.com/orbs-network/spot',
+} as const
+
+/** The two ways in: paste a prompt, or point an agent at the spec. */
+export const SPOT_ORDERS_QUICKSTART = ['human', 'agent'] as const
+
+/** Order types, in legacy order. */
+export const SPOT_ORDERS_FEATURES = ['market', 'limit', 'stopLoss', 'takeProfit', 'twap'] as const
+
+/** The execution flow. Order is the content — see `NumberedSteps`. */
+export const SPOT_ORDERS_STEPS = ['intent', 'approve', 'prepare', 'sign', 'execute'] as const
+
+/**
+ * Supported chains and their EVM IDs.
+ *
+ * In code rather than a catalog: chain names are proper nouns and the IDs are
+ * numbers, so there is nothing here for a translator to change.
+ */
+export const SPOT_ORDERS_CHAINS: readonly ChainRow[] = [
+  { name: 'Ethereum', id: 1 },
+  { name: 'BNB Chain', id: 56 },
+  { name: 'Polygon', id: 137 },
+  { name: 'Arbitrum', id: 42161 },
+  { name: 'Base', id: 8453 },
+  { name: 'Linea', id: 59144 },
+  { name: 'Avalanche', id: 43114 },
+  { name: 'Sonic', id: 146 },
+]

--- a/src/content/pages/index.ts
+++ b/src/content/pages/index.ts
@@ -14,6 +14,6 @@
  * entry here is also a slug that a post must not use — see
  * `RESERVED_ROOT_SEGMENTS`.
  */
-export const MARKETING_PAGE_PATHS = ['/dtwap', '/dlimit', '/dsltp', '/perpetual-hub', '/liquidity-hub', '/agentic'] as const
+export const MARKETING_PAGE_PATHS = ['/dtwap', '/dlimit', '/dsltp', '/perpetual-hub', '/liquidity-hub', '/agentic', '/ai/skills', '/ai/skills/spot-advanced-swap-orders'] as const
 
 export type MarketingPagePath = (typeof MARKETING_PAGE_PATHS)[number]

--- a/src/i18n/availability.ts
+++ b/src/i18n/availability.ts
@@ -65,6 +65,11 @@ const AVAILABILITY: Record<string, Partial<Record<Locale, LocaleStatus>>> = {
   // No `content/jp/agentic`, so Japanese is not offered. Korean is a real
   // translation, including the four verification steps.
   '/agentic': { en: 'translated', ko: 'translated' },
+  // `/ai` itself is NOT a page — the legacy site 404s on it. The section's
+  // entry point is this index, and one skill sits under it. Korean is a real
+  // translation of both.
+  '/ai/skills': { en: 'translated', ko: 'translated' },
+  '/ai/skills/spot-advanced-swap-orders': { en: 'translated', ko: 'translated' },
 }
 
 /**

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -466,6 +466,101 @@
         }
       },
       "disclaimer": "Orbs Agentic is a beta product under active development. All underlying digital assets, blockchain networks, and DeFi platforms are subject to ongoing development and various risks. Use at your own risk."
+    },
+    "aiSkills": {
+      "meta": {
+        "title": "AI Skills",
+        "description": "DeFi trading tools for AI coding agents like Claude Code, Cursor and Windsurf. Install a skill and let your agent place on-chain orders for you."
+      },
+      "title": "AI Skills",
+      "intro": "DeFi trading tools for AI coding agents like Claude Code, Cursor, and Windsurf. Install a skill and let your agent place on-chain orders for you.",
+      "chainsLabel": "Chains",
+      "orderTypesLabel": "Order types",
+      "items": {
+        "spotOrders": {
+          "description": "Gasless limit, stop-loss, take-profit, and TWAP orders across EVM chains. Non-custodial, oracle-protected execution using immutable, audited contracts."
+        }
+      }
+    },
+    "spotOrders": {
+      "meta": {
+        "title": "Spot Advanced Swap Orders",
+        "description": "Install this AI skill in any AI coding agent. Non-custodial, oracle-protected execution for limit, stop-loss, take-profit and TWAP orders on-chain, powered by Orbs L3."
+      },
+      "hero": {
+        "headline": "GASLESS ADVANCED\nSWAP ORDERS FOR\nAI AGENTS & HUMANS",
+        "intro": "Install this AI skill in any AI coding agent like Claude Code, Cursor, or Codex. Non-custodial, oracle-protected execution for limit, stop-loss, take-profit, and TWAP orders on-chain — powered by Orbs L3.",
+        "cta": "Get Started"
+      },
+      "quickstart": {
+        "title": "Quick Start",
+        "intro": "Install this AI skill in any AI coding agent like Claude Code, Cursor, or Codex in seconds.",
+        "items": {
+          "human": {
+            "title": "For Humans",
+            "body": "Paste this prompt into any AI coding agent."
+          },
+          "agent": {
+            "title": "For AI Agents / LLMs",
+            "body": "Point your agent to the skill spec."
+          }
+        }
+      },
+      "features": {
+        "title": "AI Agent Order Types",
+        "items": {
+          "market": {
+            "title": "Market Orders",
+            "body": "Instant gasless swaps at best available price with oracle protection."
+          },
+          "limit": {
+            "title": "Limit Orders",
+            "body": "Set a target price — the order executes automatically when the market reaches it."
+          },
+          "stopLoss": {
+            "title": "Stop-Loss",
+            "body": "Protect your position with automatic sell triggers below a price threshold."
+          },
+          "takeProfit": {
+            "title": "Take-Profit",
+            "body": "Lock in gains by auto-selling when price rises above your target."
+          },
+          "twap": {
+            "title": "TWAP / Chunked",
+            "body": "Split large orders into time-weighted chunks with oracle protection on every fill."
+          }
+        }
+      },
+      "howItWorks": {
+        "title": "How It Works",
+        "steps": {
+          "intent": {
+            "title": "Define Intent",
+            "body": "User or agent specifies: chain, tokens, amount, order type, and optional price constraints."
+          },
+          "approve": {
+            "title": "Wrap & Approve",
+            "body": "If needed, wrap native tokens and approve the contract to spend your tokens. The skill provides the calldata."
+          },
+          "prepare": {
+            "title": "Prepare Order",
+            "body": "The skill generates approval calldata, EIP-712 typed data, and relay-ready submit payloads."
+          },
+          "sign": {
+            "title": "Sign & Submit",
+            "body": "User signs with their wallet (EIP-712). The signed order is submitted to the decentralized relay."
+          },
+          "execute": {
+            "title": "Oracle-Protected Execution",
+            "body": "Orbs L3 network executes with best-price routing and oracle protection on every chunk."
+          }
+        }
+      },
+      "chains": {
+        "title": "Supported Chains",
+        "nameHeader": "Chain",
+        "idHeader": "Chain ID"
+      }
     }
   }
 }

--- a/src/i18n/messages/ko.json
+++ b/src/i18n/messages/ko.json
@@ -467,6 +467,101 @@
         }
       },
       "disclaimer": "Orbs Agentic은 현재 활발히 개발 중인 베타 제품입니다. 관련된 모든 디지털 자산, 블록체인 네트워크, DeFi 플랫폼은 지속적으로 변화하며 다양한 위험을 수반합니다. 사용에 따른 책임은 사용자에게 있습니다."
+    },
+    "aiSkills": {
+      "meta": {
+        "title": "AI Skills",
+        "description": "Claude Code, Cursor, Windsurf 같은 AI 코딩 에이전트용 DeFi 트레이딩 도구입니다. 스킬을 설치하고 에이전트가 대신 온체인 주문을 넣도록 할 수 있습니다."
+      },
+      "title": "AI 스킬",
+      "intro": "Claude Code, Cursor, Windsurf 같은 AI 코딩 에이전트용 DeFi 트레이딩 도구입니다. 스킬을 설치하고 에이전트가 대신 온체인 주문을 넣도록 할 수 있습니다.",
+      "chainsLabel": "지원체인",
+      "orderTypesLabel": "주문 유형",
+      "items": {
+        "spotOrders": {
+          "description": "EVM 체인 전반에서 가스비가 들지않는 지정가, 손절, 익절, TWAP 주문을 지원합니다. 변경 불가능하고 감사된 컨트랙트를 사용하는 비수탁형 오라클 보호 실행 방식입니다."
+        }
+      }
+    },
+    "spotOrders": {
+      "meta": {
+        "title": "Spot Advanced Swap Orders",
+        "description": "Claude Code, Cursor, Windsurf 같은 어떤 AI 코딩 에이전트에도 설치할 수 있습니다. Orbs L3 기반으로 지정가, 손절, 익절, TWAP 주문을 비수탁형 오라클 보호 방식으로 온체인에서 실행합니다."
+      },
+      "hero": {
+        "headline": "AI 에이전트와 사람을 위한\n가스리스 고급\n디파이 거래 주문",
+        "intro": "Claude Code, Cursor, Windsurf 같은 어떤 AI 코딩 에이전트에도 이 AI 스킬을 설치할 수 있습니다. Orbs L3 기반으로, 지정가 주문, 손절, 익절, TWAP 주문을 온체인에서 비수탁형이며 오라클 보호가 적용된 방식으로 실행합니다.",
+        "cta": "시작하기"
+      },
+      "quickstart": {
+        "title": "빠른 시작 가이드",
+        "intro": "Claude Code, Cursor, Windsurf 같은 어떤 AI 코딩 에이전트에도 이 AI 스킬을 몇 초 만에 설치할 수 있습니다.",
+        "items": {
+          "human": {
+            "title": "사람용",
+            "body": "이 프롬프트를 원하는 AI 코딩 에이전트에 붙여 넣으세요."
+          },
+          "agent": {
+            "title": "AI 에이전트 / LLM용",
+            "body": "에이전트가 이 스킬 명세를 참조하도록 하세요."
+          }
+        }
+      },
+      "features": {
+        "title": "AI 에이전트 주문 유형",
+        "items": {
+          "market": {
+            "title": "시장가 주문",
+            "body": "오라클 보호와 함께 현재 가능한 최적 가격으로 즉시 가스리스 스왑을 실행합니다."
+          },
+          "limit": {
+            "title": "지정가 주문",
+            "body": "목표 가격을 설정하면 시장 가격이 그 지점에 도달했을 때 주문이 자동으로 실행됩니다."
+          },
+          "stopLoss": {
+            "title": "Stop-Loss",
+            "body": "가격이 설정한 임계값 아래로 내려가면 자동 매도 트리거로 포지션을 보호합니다."
+          },
+          "takeProfit": {
+            "title": "Take-Profit",
+            "body": "가격이 목표치를 넘어서면 자동으로 매도해 수익을 확정합니다."
+          },
+          "twap": {
+            "title": "TWAP / 분할 실행",
+            "body": "대규모 주문을 시간 가중 분할로 나누어 각 체결마다 오라클 보호를 적용합니다."
+          }
+        }
+      },
+      "howItWorks": {
+        "title": "작동 방식",
+        "steps": {
+          "intent": {
+            "title": "의도 정의",
+            "body": "사용자 또는 에이전트가 체인, 토큰, 수량, 주문 유형, 선택적 가격 조건을 지정합니다."
+          },
+          "approve": {
+            "title": "래핑 및 승인",
+            "body": "필요한 경우 네이티브 토큰을 래핑하고 컨트랙트가 토큰을 사용할 수 있도록 승인합니다. 이 스킬이 calldata를 제공합니다."
+          },
+          "prepare": {
+            "title": "주문 준비",
+            "body": "이 스킬이 승인용 calldata, EIP-712 타입 데이터, 릴레이 제출용 payload를 생성합니다."
+          },
+          "sign": {
+            "title": "서명 및 제출",
+            "body": "사용자가 지갑으로 서명합니다(EIP-712). 서명된 주문은 탈중앙 릴레이로 제출됩니다."
+          },
+          "execute": {
+            "title": "오라클 보호 실행",
+            "body": "Orbs L3 네트워크가 각 분할 주문마다 최적 가격 라우팅과 오라클 보호를 적용해 실행합니다."
+          }
+        }
+      },
+      "chains": {
+        "title": "지원 체인",
+        "nameHeader": "체인",
+        "idHeader": "체인 ID"
+      }
     }
   }
 }


### PR DESCRIPTION
Seventh of #31's eight product pages — except it's **two** pages, and the issue is wrong about the URL.

## `/ai` is not a page

#31 lists `/ai` as a product page. The legacy site returns **404 for `/ai/`**. What exists is an index at `/ai/skills/` and one skill at `/ai/skills/spot-advanced-swap-orders/`. Both are built here.

That also closes the gap **#104** raised: Orbs Agentic's two primary CTAs pointed at `/ai/skills/spot-advanced-swap-orders/`, which had no route. It has one now.

## Two new components

- **`ChainTable`** — unlike Orbs Agentic's `ChainLogos`, this list carries EVM chain IDs. Two columns of one record, read by someone looking a value up, so it's a real `<table>` with column headers and the chain name as a **row header** — each ID is announced against its chain rather than as a loose number.
- **`SkillList`** — a skill is a catalogue *entry*: structured metadata (which chains, which order types) beside its description. Those are `<dl>` pairs, not prose, because they're what a reader scans for and a feature grid would flatten them. One skill today, rendered as a list so the second needs catalog entries and a route rather than a layout.

`NumberedSteps` steps can now carry a title — Orbs Agentic's four are plain sentences, these five have names ("Define Intent", "Sign & Submit") worth keeping distinct from their explanations.

## A bug a story caught

The skill card's href wasn't resolved per locale, so `/ko/ai/skills/` linked back to the **English** skill page. Now through `localeHref`; verified in the built Korean HTML (`/ko/ai/skills/spot-advanced-swap-orders/`).

## Route shape

The skill page is a concrete route, not `/ai/skills/[skill]/`. With exactly one skill, a dynamic segment would need a params source and a not-found path to serve a single page. The second skill is the moment for that, and it's noted in the route file.

## Testing

- `npx vitest run` — 134 passed. Five new stories across `ChainTable` (real table with column and row headers, names marked English) and `SkillList` (metadata as a description list, card named by the skill).
- `npm run build` — clean. All four routes prerender, English and Korean.
- `npm run lint`, `npx tsc --noEmit` — clean.
- **Visual review** via #93.

Korean is a real translation of both pages. No Japanese content exists for either.