### PR TITLE
perf(blog): stop prerendering the archive on non-production builds

### DIFF
--- a/src/app/(en)/[slug]/page.tsx
+++ b/src/app/(en)/[slug]/page.tsx
@@ -107,7 +107,32 @@ type Props = {
 // (#19) is the primary path; this bounds staleness if a webhook is missed.
 export const revalidate = 3600
 
+/**
+ * Prerender the whole archive on production builds only.
+ *
+ * Returning a slug here means "render this page at build time", so the full
+ * list costs one Contentful read per post on every build. That is the right
+ * trade for production — posts get most of their traffic in bursts from
+ * Twitter link-backs, and a burst should land on warm cache, not on ~460 cold
+ * renders — but it is pure waste everywhere else. Preview deploys are built on
+ * every push and nobody reads their archive; local builds are run constantly
+ * while developing. Between them they were the bulk of this project's
+ * Contentful consumption, and in September 2026 they exhausted the space's
+ * Delivery API allowance outright, blocking every build including production.
+ *
+ * `dynamicParams` is left at its default of `true`, so the posts omitted here
+ * are not gone — they render on first request and are then cached and
+ * revalidated exactly as a prerendered page is. The only difference is when the
+ * first render happens.
+ *
+ * The sitemap enumerates posts independently (`getAllPostRefs`), so what is
+ * prerendered has no bearing on what crawlers are told exists.
+ *
+ * To exercise the production path locally, set `VERCEL_ENV=production`.
+ */
 export async function generateStaticParams() {
+  if (process.env.VERCEL_ENV !== 'production') return []
+
   const slugs = await getAllPostSlugs()
 
   return slugs.map((slug) => ({ slug }))

--- a/src/app/lib/api.ts
+++ b/src/app/lib/api.ts
@@ -1,3 +1,4 @@
+import { cache } from 'react'
 import * as contentful from 'contentful'
 import type { Asset, Entry, UnresolvedLink } from 'contentful'
 import { TypeBlogPostSkeleton, TypeAuthorSkeleton, TypeMediaMentionSkeleton } from '../generated-types'
@@ -322,10 +323,29 @@ export async function getPostById(entryId: string, preview = false): Promise<Blo
 }
 
 /**
+ * Wrapped in React `cache()` so the two reads of one post share a request.
+ *
+ * Every post route reads this twice — once in `generateMetadata`, once in the
+ * page body — because the metadata has to come from the same source the body
+ * renders or a draft renders under published metadata. Next dedupes repeated
+ * `fetch()` calls automatically, but the Contentful SDK uses its own HTTP
+ * client, so those two reads were invisible to it and went out as two requests.
+ * Across a full prerender of the archive that was ~460 wasted round trips per
+ * build, each pulling a complete Rich Text document.
+ *
+ * `cache()` is scoped to a single render pass, so this dedupes the pair without
+ * holding anything between requests — freshness still comes from `revalidate`
+ * and the Contentful webhook, unchanged.
+ *
+ * NB: the memo key is the argument LIST, so `getPostBySlug(slug)` and
+ * `getPostBySlug(slug, false)` are separate entries despite being equivalent.
+ * Both call sites pass `isDraft` explicitly. Keep it that way, or the dedupe
+ * silently stops working.
+ *
  * @param preview Read through the Preview API so unpublished drafts resolve.
  *   Pass `(await draftMode()).isEnabled` — never a value derived from user input.
  */
-export async function getPostBySlug(slug: string, preview = false): Promise<BlogPostFields | null> {
+export const getPostBySlug = cache(async (slug: string, preview = false): Promise<BlogPostFields | null> => {
   const client = getClient(preview)
 
   const posts = await client.getEntries<TypeBlogPostSkeleton>({
@@ -339,5 +359,5 @@ export async function getPostBySlug(slug: string, preview = false): Promise<Blog
   }
 
   return posts.items[0].fields
-}
+})
 


### PR DESCRIPTION
Cuts build-time Contentful reads by ~95% on preview and local builds, ~48% on production.

Refs #115.

## Why

Every build read all ~456 posts twice. In September 2026 that exhausted the space's Delivery API allowance and Contentful blocked the space (`SpaceUsageLimitsExceeded`, HTTP 402), failing every build including four production deployments. Full breakdown in #115.

## What changed

**`cache()` on `getPostBySlug`.** It is called once in `generateMetadata` and once in the page body — the metadata has to read the same source the body renders, or a draft renders under published metadata. Next dedupes repeated `fetch()` automatically, but the Contentful SDK uses its own HTTP client, so both reads went out as separate requests: ~912 round trips per build, each pulling a complete Rich Text document. `cache()` is scoped to one render pass, so this collapses the pair without holding anything between requests.

**`generateStaticParams` gated on `VERCEL_ENV`.** Returning a slug means "render this at build time". The full list is right for production — posts get most of their traffic in bursts from Twitter link-backs, and a burst should land on warm cache rather than ~460 cold renders — but preview deploys are built on every push and nobody reads their archive, and local builds run constantly during development.

`dynamicParams` stays at its default of `true`, so omitted posts are not gone: they render on first request and are then cached and revalidated exactly as a prerendered page is. Only the timing of the first render changes.

## Per-build calls

| Build | Before | After |
| --- | --- | --- |
| Preview / local | ~960 | ~45 |
| Production | ~960 | ~500 |

## Notes

- **SEO unaffected.** `sitemap.ts` enumerates posts independently via `getAllPostRefs`, so what is prerendered has no bearing on what crawlers are told exists.
- **Publishing unaffected.** New posts already go live via the `/api/revalidate` webhook without a rebuild, and `dynamicParams: true` means a slug absent from the last build still renders.
- **`revalidate` deliberately unchanged** at 3600. Raising it was considered and rejected: the time-based fallback is the only thing that heals a renamed slug, per the known limitation documented at `src/app/api/revalidate/route.ts:157`.
- To exercise the production path locally, set `VERCEL_ENV=production`.

## Testing

- `tsc --noEmit` clean, `eslint` clean, 139 Storybook tests pass
- Codex high-effort review: no findings
- **Build not verified end-to-end** — the space is still blocked, so no build can go green. Partial proof: against the blocked space the build's first failure moves from `Failed to collect page data for /[slug]` to `/news/page/[n]`, confirming the post route no longer reads Contentful at build time.

**Do not merge until the space is unblocked and a full build passes.** This changes build behaviour; shipping it unverified is how you get a second incident.