### PR TITLE
perf: prerender only the newest posts, and cache the sitemap at the edge

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -26,6 +26,36 @@ const nextConfig = {
   },
   // Enable React Compiler for automatic memoization (Next.js 16)
   reactCompiler: true,
+  /**
+   * Edge-cache the sitemap.
+   *
+   * `sitemap.ts` is `force-dynamic` — it has to be, or `absoluteUrl()` freezes
+   * the build-time SITE_URL into every `<loc>` (#71) — which means every
+   * request costs two Contentful reads, `getAllPostRefs` plus
+   * `getMediaSummary`. Crawlers poll a sitemap on their own schedule, so that
+   * is the one remaining path to the Delivery API with no ceiling on it (#115).
+   *
+   * The header lives here rather than in the route because a Next metadata
+   * route returns a `MetadataRoute.Sitemap` array, not a `Response`, so it has
+   * nowhere to set one itself. The RSS feed, which is a route handler, sets the
+   * equivalent header inline.
+   *
+   * A day of staleness is invisible to crawlers: they recheck on a much longer
+   * cycle than that, and `<lastmod>` tells them what actually moved.
+   */
+  async headers() {
+    return [
+      {
+        source: '/sitemap.xml',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=0, s-maxage=86400, stale-while-revalidate=604800',
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default withNextIntl(nextConfig)

--- a/src/app/(en)/[slug]/page.tsx
+++ b/src/app/(en)/[slug]/page.tsx
@@ -108,22 +108,39 @@ type Props = {
 export const revalidate = 3600
 
 /**
- * Prerender the whole archive on production builds only.
+ * How much of the archive a production build renders ahead of time.
  *
- * Returning a slug here means "render this page at build time", so the full
- * list costs one Contentful read per post on every build. That is the right
- * trade for production — posts get most of their traffic in bursts from
- * Twitter link-backs, and a burst should land on warm cache, not on ~460 cold
- * renders — but it is pure waste everywhere else. Preview deploys are built on
- * every push and nobody reads their archive; local builds are run constantly
- * while developing. Between them they were the bulk of this project's
- * Contentful consumption, and in September 2026 they exhausted the space's
- * Delivery API allowance outright, blocking every build including production.
+ * Sized to the traffic pattern rather than the archive. Posts get their views
+ * in bursts from Twitter link-backs, and what gets linked is a post that was
+ * just published — so warming the newest window covers essentially every burst,
+ * while the older ~400 posts, which are linked rarely and read rarely, do not
+ * need to be paid for on every deploy.
+ *
+ * Raise it if link-backs to older posts turn out to be common. The cost is
+ * linear: one Contentful read per post per production build.
+ */
+const PRERENDERED_POST_COUNT = 50
+
+/**
+ * Prerender the newest posts, and only on production builds.
+ *
+ * Returning a slug here means "render this page at build time", so each one
+ * costs a Contentful read on every build. Two things bound that:
+ *
+ *  - **Environment.** Preview deploys are built on every push and nobody reads
+ *    their archive; local builds run constantly while developing. Between them
+ *    they were the bulk of this project's Contentful consumption, and in
+ *    September 2026 they exhausted the space's Delivery API allowance outright,
+ *    blocking every build including production (#115).
+ *  - **Count.** Prerendering all ~456 posts made deploys the single largest
+ *    consumer even after the environment gate — roughly 15% of the monthly
+ *    allowance spent on shipping rather than on serving anyone.
  *
  * `dynamicParams` is left at its default of `true`, so the posts omitted here
- * are not gone — they render on first request and are then cached and
- * revalidated exactly as a prerendered page is. The only difference is when the
- * first render happens.
+ * are not gone: they render on first request and are then cached and
+ * revalidated exactly as a prerendered page is. The only difference is who pays
+ * for the first render — and for a post nobody has opened in a year, nobody
+ * was going to.
  *
  * The sitemap enumerates posts independently (`getAllPostRefs`), so what is
  * prerendered has no bearing on what crawlers are told exists.
@@ -133,9 +150,11 @@ export const revalidate = 3600
 export async function generateStaticParams() {
   if (process.env.VERCEL_ENV !== 'production') return []
 
+  // Newest first — `getAllPostSlugs` preserves POST_ORDER, so this is the most
+  // recent window rather than an arbitrary slice.
   const slugs = await getAllPostSlugs()
 
-  return slugs.map((slug) => ({ slug }))
+  return slugs.slice(0, PRERENDERED_POST_COUNT).map((slug) => ({ slug }))
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {


### PR DESCRIPTION
Refs #115. Closes the last two uncapped paths to the Delivery API.

## 1. Production builds prerendered the whole archive

After #116 gated preview and local builds, production deploys became the single largest consumer — ~500 reads each, ~15k a month at a normal release cadence, spent on shipping rather than on serving anyone.

Now prerenders the newest **50**. Sized to the traffic pattern rather than the archive: link-backs from Twitter point at posts that were just published, so the newest window covers essentially every burst. The older ~400 render on first request via `dynamicParams` and cache identically from then on.

The trade is one cold render per hour for the first visitor to an old post — a page that currently gets near-zero traffic. `PRERENDERED_POST_COUNT` is a named constant; raise it if link-backs to older posts turn out to be common.

## 2. The sitemap had no ceiling at all

`sitemap.ts` is `force-dynamic` and must stay that way, or `absoluteUrl()` bakes the build-time SITE_URL into every `<loc>` (#71). So every crawler request cost two reads (`getAllPostRefs` + `getMediaSummary`), scaling with bot behaviour rather than anything we control.

Now carries a day-long `s-maxage`. The header is set in `next.config.mjs` because a Next metadata route returns a `MetadataRoute.Sitemap` array, not a `Response`, and has nowhere to set one itself — unlike the RSS feed, which is a route handler and sets the equivalent header inline.

## Projected monthly, against a 100k allowance

| Stage | Calls/month |
| --- | --- |
| Before #116 | 100k+ (space blocked) |
| After #116 + #117 | ~32,000 |
| After this | ~12,000 |

## Testing

- `tsc --noEmit` clean, `eslint` clean, 139 Storybook tests pass
- Codex review: no findings

**One thing is unverified and needs checking before this is trusted.** I could not confirm the `next.config.mjs` header rule actually applies to `/sitemap.xml`, because `.next/routes-manifest.json` is written *after* page-data collection and the build dies there on the Contentful 402. Custom headers from `next.config` should take precedence over what Next sets for a dynamic route, but I have not proven it on this route.

Once the space is unblocked, verify with:

```
curl -sI https://<deployment>/sitemap.xml | grep -i "cache-control\|x-vercel-cache"
```

Expect `s-maxage=86400` and a `HIT` on the second request. **If Next overrides it**, the fallback is to convert `sitemap.ts` into a route handler at `app/sitemap.xml/route.ts` that returns a `Response` with explicit headers — the pattern the RSS feed already uses and which is proven to work in this codebase. I did not do that up front because it means hand-rolling the XML that `MetadataRoute.Sitemap` currently serialises, including the `alternates` hreflang sets, which is real risk to take on for a problem that may not exist.

The post-prerender change in part 1 is independent of this and is verified.