### PR TITLE
chore(rss): merge the two stacked doc comments into one

### DIFF
--- a/src/app/(en)/blog/rss.xml/route.ts
+++ b/src/app/(en)/blog/rss.xml/route.ts
@@ -10,8 +10,7 @@ import { absoluteUrl, siteUrl } from '@/app/lib/site'
  *
  * Generated from Contentful rather than by parsing built HTML, which is what
  * the old `build-rss-feed.js` did.
- */
-/**
+ *
  * Rendered per request, then cached at the edge by the `Cache-Control` header
  * the handler sets — see `GET`.
  *


### PR DESCRIPTION
Tier 1, comment text only.

#117 inserted a second JSDoc block between the route's existing description and the `export const dynamic` it documented, leaving two adjacent comments with the first orphaned from anything. Merged into one block; no lines of code changed.

`tsc --noEmit` and `eslint` clean.